### PR TITLE
make fetch_bot_info response handling consistent 

### DIFF
--- a/tiger_agent/harness.py
+++ b/tiger_agent/harness.py
@@ -205,17 +205,17 @@ class AgentHarness:
 
     @logfire.instrument("fetch_bot_info", extract_args=False)
     async def _fetch_bot_info(self):
-        resp = await self.app.client.auth_test()
-        data = resp.get("data")
+        auth_test_response = await self.app.client.auth_test()
         
-        assert isinstance(data, dict), "resp.data must be a dict"
-        assert data.get("ok"), "slack auth_test failed"
+        assert isinstance(auth_test_response, dict), "resp.data must be a dict"
+        assert auth_test_response.get("ok"), "slack auth_test failed"
         
-        bot_id = data.get("bot_id")
+        bot_id = auth_test_response.get("bot_id")
         
-        bot_info = await self.app.client.bots_info(bot=bot_id)
+        bots_info_response = await self.app.client.bots_info(bot=bot_id)
+        assert bots_info_response.get("ok"), "slack bots_info failed"
         
-        bot = bot_info.get("bot")
+        bot = bots_info_response.get("bot")
         
         assert isinstance(bot, dict), "bot must be a dict"
         


### PR DESCRIPTION
This is a follow up for these comments:
https://github.com/timescale/tiger-agent/pull/30#discussion_r2359736397
https://github.com/timescale/tiger-agent/pull/30#discussion_r2359721441
