### PR TITLE
fix: remove unneeded ctx argument to augment_mcp_servers

### DIFF
--- a/tiger_agent/agent.py
+++ b/tiger_agent/agent.py
@@ -231,7 +231,7 @@ class TigerAgent:
         system_prompt = await self.make_system_prompt(ctx)
         user_prompt = await self.make_user_prompt(ctx)
         mcp_servers = self.mcp_loader()
-        self.augment_mcp_servers(mcp_servers, ctx)
+        self.augment_mcp_servers(mcp_servers)
         toolsets = [mcp_server for mcp_server in mcp_servers.values()]
         agent = Agent(
             model=self.model,


### PR DESCRIPTION
#38 introduced a bug in the default agent, where it was calling `self.augment_mcp_servers` with `ctx` as an argument, though the function only accepts `(self, mcp_servers)`. I had originally thought to pass it, but decided against it, where when setting `process_tool_call`, the caller function will have access to the context via its function parameters, and so doesn't need to have `ctx` passed to it from the `generate_response` message.

Removing it for now until we have a use case that makes sense where we pass `ctx` as an argument then.