### PR TITLE
chore: update publish job name

### DIFF
--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -10,8 +10,8 @@ permissions:
   contents: read
 
 jobs:
-  docker-publish-mcp:
-    name: docker-publish-mcp
+  docker-publish:
+    name: docker-publish
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
PR renames the `docker-publish-mcp` job name to be `docker-publish` since we're not publishing a mcp here and it's weird to see that. This was a result of me just copy/pasting the job from another repo without looking at the name, whoops.