### PR TITLE
feat: always set a tool_prefix when loading MCP servers

### DIFF
--- a/tiger_agent/agent.py
+++ b/tiger_agent/agent.py
@@ -71,6 +71,8 @@ def create_mcp_servers(mcp_config: dict[str, dict[str, Any]]) -> MCPDict:
     for name, cfg in mcp_config.items():
         if cfg.pop("disabled", False):
             continue
+        if not cfg.get("tool_prefix"):
+            cfg["tool_prefix"] = name
         if cfg.get("command"):
             mcp_servers[name] = MCPServerStdio(**cfg)
         elif cfg.get("url"):


### PR DESCRIPTION
PR updates our mcp loader so that if a user does not provide a `tool_prefix` in their mcp config, then we just use the key instead. This should simplify usage for consumers where they don't really need to worry about tool name collisions and the prefix stuff.

This brings behavior inline with how how other tools also work (e.g. claude code) where they always have the prefix of the "mcp name", for similar reasons.