### PR TITLE
fix: skip invalid saved events

### DIFF
--- a/tiger_agent/migrations/idempotent/001-event.sql
+++ b/tiger_agent/migrations/idempotent/001-event.sql
@@ -52,7 +52,7 @@ $func$ language sql volatile security invoker
 
 -----------------------------------------------------------------------
 -- agent.delete_event
-create or replace function agent.delete_event(_id int8) returns void
+create or replace function agent.delete_event(_id int8, _processed boolean default true) returns void
 as $func$
     with d as
     (
@@ -67,6 +67,7 @@ as $func$
     , vt
     , claimed
     , event
+    , processed
     )
     select
       d.id
@@ -75,6 +76,7 @@ as $func$
     , d.vt
     , d.claimed
     , d.event
+    , _processed
     from d
     ;
 $func$ language sql volatile security invoker

--- a/tiger_agent/migrations/incremental/002-event-processed.sql
+++ b/tiger_agent/migrations/incremental/002-event-processed.sql
@@ -1,0 +1,6 @@
+--002-event-processed.sql
+
+-----------------------------------------------------------------------
+-- Add processed column to agent.event_hist
+alter table agent.event_hist
+add column processed boolean not null default true;


### PR DESCRIPTION
PR fixes a bug we saw over the weekend where somehow slack had sent an invalid payload for `app_mention` with what we were expecting. Currently, when this happens, we end up throwing a `pydantic.ValidationError` that's not caught and brings the entire app down. The fix is to catch this, log it, and then delete the event to prevent trying to process it again. To help in tracking this, I've also added a new boolean column to `agent.event_hist` that can be used to track whether or not an event was successfully processed or not.

We've only ever seen the payload once now, so it's unclear how this might have happened, so don't think it's worth digging to much into it until we've seen it more consistently.