### PR TITLE
refactor: remove unused TigerAgent instance variable

### DIFF
--- a/tiger_agent/harness.py
+++ b/tiger_agent/harness.py
@@ -73,11 +73,9 @@ class HarnessContext:
     Attributes:
         app: Slack Bolt AsyncApp for making Slack API calls
         pool: Database connection pool for PostgreSQL operations
-        task_group: AsyncIO TaskGroup for spawning concurrent tasks
     """
     app: AsyncApp
     pool: AsyncConnectionPool
-    task_group: TaskGroup
 
 
 class AppMentionEvent(BaseModel):
@@ -333,7 +331,6 @@ class EventHarness:
         return HarnessContext(
             self._app,
             self._pool,
-            self._task_group,
         )
 
     async def _process_event(self, event: Event) -> bool:


### PR DESCRIPTION
PR removes an unused instance variable from TigerAgent, `self._task_group`. My guess was that it was meant to be set as part of the `run` method, where then we'd set it on the `HarnessContext` which would make it available to the `EventProcessor` function, but I'm not exactly certain why we'd want that and it feels like could lead to some weird behavior if it was used that way.

For now, I think better to remove this until there's an actual need for it, instead of fixing it to be defined.