### PR TITLE
Add the whole event to the claim event action

### DIFF
--- a/tiger_agent/harness.py
+++ b/tiger_agent/harness.py
@@ -353,7 +353,7 @@ class EventHarness:
         Returns:
             bool: True if processing succeeded, False if it failed
         """
-        with logfire.span("process_event", event_id=event.id) as _:
+        with logfire.span("process_event", event=event) as _:
             try:
                 await self._event_processor(self._make_harness_context(), event)
                 await self._delete_event(event)


### PR DESCRIPTION
Rather than just the event id, let's add the whole event so we have instant access to the request.


Example:
<img width="387" height="338" alt="image" src="https://github.com/user-attachments/assets/d3c8c19e-c691-4b3c-99be-cf1bb6347ca2" />
[Span](https://logfire-us.pydantic.dev/tigerdata/tiger-agents?q=trace_id%3D%270199c515ff1ee115156d16bc376ae2aa%27+and+span_id%3D%27412229dcbb3300b8%27&spanId=412229dcbb3300b8&traceId=0199c515ff1ee115156d16bc376ae2aa&env=-clear-&since=2025-10-08T18%3A29%3A37.182627Z&until=2025-10-08T18%3A29%3A42.176118Z)

So you can search like this:
<img width="986" height="328" alt="image" src="https://github.com/user-attachments/assets/76142f13-8c44-4023-9c0e-10818eb7b071" />
