### PR TITLE
feat: implement support for slash commands

### DIFF
--- a/examples/memory_agent.py
+++ b/examples/memory_agent.py
@@ -1,0 +1,81 @@
+import asyncio
+from dotenv import load_dotenv, find_dotenv
+import jinja2
+from jinja2 import FileSystemLoader
+from pathlib import Path
+from pydantic import BaseModel, Field
+from typing import Any
+
+from tiger_agent import TigerAgent, HarnessContext, Command, SlackHarness
+from tiger_agent.log_config import setup_logging
+from tiger_agent.slack import post_ephermal
+
+
+class Memory(BaseModel):
+    id: str = Field(description="The unique identifier of this memory.")
+    content: str = Field(description="The content of this memory.")
+    source: str | None = Field(
+        default=None,
+        description="The source or origin of this memory. A deep URI to the origin of the fact is preferred (e.g., a specific URL, file path, or reference).",
+    )
+    created_at: str = Field(
+        description="The date and time when this memory was created."
+    )
+    updated_at: str = Field(
+        description="The date and time when this memory was last updated."
+    )
+
+
+class MemoriesResponse(BaseModel):
+    memories: list[Memory] = Field(
+        default=[], description="The list of memories found."
+    )
+    scope: str = Field(
+        description="A unique identifier for the target set of memories. Can be any combination of user and application ids, as needed for scoping and personalization."
+    )
+
+
+class MemoryAgent(TigerAgent):
+    async def command_processor(self, context: HarnessContext, command: Command) -> None:
+        print("Command received:", command)
+        if command.text.lower() == "list":
+            mcp_servers = self.mcp_loader()
+            mcp_memory = mcp_servers.get("memory")
+            if mcp_memory:
+                response = await mcp_memory.direct_call_tool("recall", {"scope": f"eon:{command.user_id}"}, None)
+                memories = MemoriesResponse.model_validate(response).memories
+                response_text = "Memories:\n" + "\n".join(f" - {mem.content}" for mem in memories)
+                await post_ephermal(
+                    context.app.client,
+                    channel=command.channel_id or '',
+                    user=command.user_id,
+                    text=response_text,
+                    replace_original=True,
+                    delete_original=True
+                )
+
+
+def main():
+    load_dotenv(dotenv_path=find_dotenv(usecwd=True))
+    setup_logging()
+
+    # build our agent
+    agent = MemoryAgent(
+        model="anthropic:claude-sonnet-4-5-20250929",
+        mcp_config_path=Path(__file__).resolve().parent / "memory_mcp_config.json",
+        jinja_env=jinja2.Environment(
+            enable_async=True,
+            loader=FileSystemLoader(Path(__file__).resolve().parent.parent / "prompts")
+        )
+    )
+
+    # create a harness for the processor
+    harness = SlackHarness(
+        agent,
+    )
+
+    # run the harness
+    asyncio.run(harness.run())
+
+if __name__ == "__main__":
+    main()

--- a/examples/memory_mcp_config.json
+++ b/examples/memory_mcp_config.json
@@ -1,0 +1,5 @@
+{
+  "memory": {
+    "url": "http://tiger-memory-mcp-server/mcp"
+  }
+}

--- a/prompts/user_prompt.md
+++ b/prompts/user_prompt.md
@@ -8,10 +8,10 @@ local time zone: {{ user.tz }}
 {% endif %}
 
 **Message Details:**
-channel: {{ mention.channel }}
-ts: {{ mention.ts }}
-{% if mention.thread_ts %}thread_ts: {{ mention.thread_ts }}{% endif %}
+channel: {{ event.channel }}
+ts: {{ event.ts }}
+{% if event.thread_ts %}thread_ts: {{ event.thread_ts }}{% endif %}
 event_ts: {{ event.event_ts }}
 
 **Respond to this message:**
-{{ mention.text }}
+{{ event.text }}

--- a/tiger_agent/__init__.py
+++ b/tiger_agent/__init__.py
@@ -1,6 +1,6 @@
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
-from .harness import EventHarness, Event, HarnessContext, EventProcessor, AppMentionEvent
+from .harness import EventHarness, Interaction, SlackHarness, HarnessContext, SlackProcessor, AppMentionEvent, Command
 from .agent import TigerAgent
 
-__all__ = ["EventHarness", "TigerAgent", "HarnessContext", "Event", "AppMentionEvent", "EventProcessor", "__version__"]
+__all__ = ["EventHarness", "SlackHarness", "TigerAgent", "HarnessContext", "Interaction", "AppMentionEvent", "SlackProcessor", "Command", "__version__"]

--- a/tiger_agent/migrations/incremental/003-interaction.sql
+++ b/tiger_agent/migrations/incremental/003-interaction.sql
@@ -1,0 +1,35 @@
+--003-interaction.sql
+
+-----------------------------------------------------------------------
+-- Rename agent.event table to agent.interaction and update columns
+
+-- Rename the main table
+alter table agent.event rename to interaction;
+
+-- Rename columns in the interaction table
+alter table agent.interaction rename column event_ts to interaction_ts;
+alter table agent.interaction rename column event to interaction;
+
+-- Add type column with default, backfill, then add NOT NULL constraint
+alter table agent.interaction add column type text;
+update agent.interaction set type = 'event';
+alter table agent.interaction alter column type set not null;
+
+-- Drop old index and create new one with updated column name
+drop index agent.event_vt_attempts_idx;
+create index on agent.interaction (vt, attempts);
+
+-----------------------------------------------------------------------
+-- Rename agent.event_hist table to agent.interaction_hist and update columns
+
+-- Rename the history table
+alter table agent.event_hist rename to interaction_hist;
+
+-- Rename columns in the interaction_hist table
+alter table agent.interaction_hist rename column event_ts to interaction_ts;
+alter table agent.interaction_hist rename column event to interaction;
+
+-- Add type column with default (no NOT NULL needed for history table)
+alter table agent.interaction_hist add column type text;
+update agent.interaction_hist set type = 'event';
+alter table agent.interaction_hist alter column type set not null;

--- a/tiger_agent/migrations/incremental/004-drop-old-functions.sql
+++ b/tiger_agent/migrations/incremental/004-drop-old-functions.sql
@@ -1,0 +1,9 @@
+--004-drop-old-functions.sql
+
+-----------------------------------------------------------------------
+-- Drop old function names after renaming to interaction
+
+drop function if exists agent.insert_event(jsonb);
+drop function if exists agent.claim_event(int4, interval);
+drop function if exists agent.delete_event(int8, boolean);
+drop function if exists agent.delete_expired_events(int, interval);

--- a/tiger_agent/slack.py
+++ b/tiger_agent/slack.py
@@ -173,6 +173,36 @@ async def post_response(
     )
 
 
+@logfire.instrument("post_ephermal", extract_args=["channel", "user"])
+async def post_ephermal(
+    client: AsyncWebClient, channel: str, user: str, text: str, **kwargs
+) -> None:
+    """Post an ephermal (private) message to a Slack user in a channel.
+
+    Posts a private message visible only to the specified user within the given
+    channel. Uses markdown blocks for rich text formatting and disables link/media
+    unfurling to keep responses clean.
+
+    Args:
+        client: Slack AsyncWebClient for API calls
+        channel: Slack channel ID to post in
+        user: Slack user ID to send the ephermal message to
+        text: Message content with markdown formatting support
+
+    Raises:
+        SlackApiError: If message posting fails (not caught, allows caller to handle)
+    """
+    await client.chat_postEphemeral(
+        channel=channel,
+        user=user,
+        text=text,
+        blocks=[{"type": "markdown", "text": text}],
+        unfurl_links=False,
+        unfurl_media=False,
+        **kwargs,
+    )
+
+
 class BotInfo(BaseModel):
     """Pydantic model for Slack bot information.
 


### PR DESCRIPTION
PR implements support for slash command handling in the agents. The original setup was centered around the concept of "events" (corresponding to slack events), and had a lot of naming to that effect. To incorporate slash commands, I moved to having the naming be centered around "interactions", under which we have "events" and "commands" (and can have future slack interactions like "actions" or "shortcuts" or "modals" or "views"). 

The refactoring at a high level looks like this:

* Rename the `EventHarness` to `SlackHarness` to show that it handles more than events
* Use a regex for `app.event` and `app.command` so that the agent listens to all events/commands that were configured via Slack
* Add a new `SlackProcessor` abstract class that concrete classes would implement the `event_processor` and `command_processor` functions for what they handle
* Rename `agent.event` table (and some inner columns) to `agent.interaction`
* Rename all the DB functions to be `agent.*_event` to `agent.*_interaction` (e.g. `agent.claim_event` -> `agent.claim_interaction`)

---

The command demo is given by `examples/memory_agent.py` where I've added a `/mpeveler-memory` command for the bot, and when I type "list" I get all current memories:

<img width="389" height="200" alt="Screenshot 2025-10-13 at 10 27 53 PM" src="https://github.com/user-attachments/assets/9907ae48-8abe-42fc-9c54-4571e6ad8433" />

I could then extend this to support "add" and "update" or whatever.