### PR TITLE
fix: make UserInfo.deleted field optional

### DIFF
--- a/tiger_agent/slack.py
+++ b/tiger_agent/slack.py
@@ -111,7 +111,7 @@ class UserInfo(BaseModel):
     id: str
     team_id: str
     name: str
-    deleted: bool
+    deleted: Optional[bool] = False
     color: Optional[str] = None
     real_name: Optional[str] = None
     tz: Optional[str] = None


### PR DESCRIPTION
PR makes the `UserInfo.deleted` field optional, as we were seeing in some cases today that the Slack API was not returning it. Given that we don't currently rely on the field, I think fine to make it optional, and if we don't receive it from Slack, then we can just assume the user hasn't been deleted yet.

For reference, the field seems to have been missing from responses from the [`users.info`](https://docs.slack.dev/reference/methods/users.info/) API method for about a 30 minute window today, but otherwise operated as expected, so I don't think this PR is strictly necessary now, but better to be overly defensive as we've seen flakiness with Slack APIs randomly for other methods.