### PR TITLE
[AGE-233] Remove CLI types and parse

### DIFF
--- a/tiger_agent/main.py
+++ b/tiger_agent/main.py
@@ -3,8 +3,11 @@ from datetime import timedelta
 from pathlib import Path
 
 import click
+import jinja2
 from dotenv import find_dotenv, load_dotenv
+from jinja2 import FileSystemLoader
 
+from tiger_agent import EventHarness, TigerAgent
 from tiger_agent.log_config import setup_logging
 
 
@@ -18,15 +21,15 @@ def cli():
 @click.option("--prompts", type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path), default=Path("prompts"), help="Directory containing prompt templates")
 @click.option("--mcp-config", type=click.Path(exists=True, path_type=Path), default=None, help="Path to MCP config file")
 @click.option("--env", type=click.Path(exists=True, path_type=Path), default=None, help="Path to environment file")
-@click.option("--worker-sleep-seconds", type=int, default=60, help="Worker sleep duration in seconds")
-@click.option("--worker-min-jitter-seconds", type=int, default=-15, help="Minimum jitter for worker sleep")
-@click.option("--worker-max-jitter-seconds", type=int, default=15, help="Maximum jitter for worker sleep")
-@click.option("--max-attempts", type=int, default=3, help="Maximum retry attempts for failed tasks")
-@click.option("--max-age-minutes", type=int, default=60, help="Maximum age of an event before expiring")
-@click.option("--invisibility-minutes", type=int, default=10, help="Task invisibility timeout in minutes")
-@click.option("--num-workers", type=int, default=5, help="Number of worker processes")
-@click.option("--rate-limit-allowed-requests", type=int, default=None, help="Number of allowed requests per user, per interval (interval is, by default 1 minute, use --rate-limit-interval to override)")
-@click.option("--rate-limit-interval", type=int, default=1, help="The rate limit interval in minutes, used to determine if a user has exceeded the rate limit. Only used if --rate-limit-count is set")
+@click.option("--worker-sleep-seconds", default=60, help="Worker sleep duration in seconds")
+@click.option("--worker-min-jitter-seconds", default=-15, help="Minimum jitter for worker sleep")
+@click.option("--worker-max-jitter-seconds", default=15, help="Maximum jitter for worker sleep")
+@click.option("--max-attempts", default=3, help="Maximum retry attempts for failed tasks")
+@click.option("--max-age-minutes", default=60, help="Maximum age of an event before expiring")
+@click.option("--invisibility-minutes", default=10, help="Task invisibility timeout in minutes")
+@click.option("--num-workers", default=5, help="Number of worker processes")
+@click.option("--rate-limit-allowed-requests", default=None, help="Number of allowed requests per user, per interval (interval is, by default 1 minute, use --rate-limit-interval to override)")
+@click.option("--rate-limit-interval", default=1, help="The rate limit interval in minutes, used to determine if a user has exceeded the rate limit. Only used if --rate-limit-count is set")
 def run(
     model: str,
     prompts: Path,
@@ -43,10 +46,19 @@ def run(
     rate_limit_interval: int = 1,
 ):
     """Run the Tiger Agent bot"""
-    import jinja2
-    from jinja2 import FileSystemLoader
+    # Parse integer arguments
+    worker_sleep_seconds = int(worker_sleep_seconds)
+    worker_min_jitter_seconds = int(worker_min_jitter_seconds)
+    worker_max_jitter_seconds = int(worker_max_jitter_seconds)
+    max_attempts = int(max_attempts)
+    max_age_minutes = int(max_age_minutes)
+    invisibility_minutes = int(invisibility_minutes)
+    num_workers = int(num_workers)
+    if rate_limit_allowed_requests is not None:
+        rate_limit_allowed_requests = int(rate_limit_allowed_requests)
+    rate_limit_interval = int(rate_limit_interval)
 
-    from tiger_agent import EventHarness, TigerAgent
+  
 
     load_dotenv(dotenv_path=env if env else find_dotenv(usecwd=True))
     setup_logging()


### PR DESCRIPTION
Because Kubernetes mandates string arguments, we need to allow for integers to be strings, then parse them

Thread: https://iobeam.slack.com/archives/C09AF06P37B/p1761591088659789?thread_ts=1761586670.237329&cid=C09AF06P37B