### PR TITLE
fix: not all events have a client_msg_id

### DIFF
--- a/tiger_agent/harness.py
+++ b/tiger_agent/harness.py
@@ -99,7 +99,6 @@ class BaseEvent(BaseModel):
         blocks: Slack Block Kit blocks if present
         channel: Channel ID where the mention occurred
         event_ts: Event timestamp from Slack
-        client_msg_id: Unique client message identifier
     """
     model_config = {"extra": "allow"}
 
@@ -112,7 +111,6 @@ class BaseEvent(BaseModel):
     blocks: list[dict[str, Any]] | None = None
     channel: str
     event_ts: str
-    client_msg_id: str
 
 
 class AppMentionEvent(BaseEvent):


### PR DESCRIPTION
We encountered some messages that don't have a `client_msg_id`, and we aren't using it anyway.

```json
{
    "ts": "1761580687.559649",
    "team": "T02FBQQDT",
    "text": "<@U086M6G6X28> archived the channel <#C09NPGQM6LR>",
    "type": "message",
    "user": "USLACKBOT",
    "blocks": [
        {
            "type": "rich_text",
            "block_id": "sKf",
            "elements": [
                {
                    "type": "rich_text_section",
                    "elements": [
                        {
                            "type": "user",
                            "user_id": "U086M6G6X28"
                        },
                        {
                            "text": " archived the channel ",
                            "type": "text"
                        },
                        {
                            "type": "channel",
                            "channel_id": "C09NPGQM6LR"
                        }
                    ]
                }
            ]
        }
    ],
    "channel": "D095RJGHEE6",
    "subtype": "im",
    "event_ts": "1761580687.559649",
    "channel_type": "im"
}
```