### PR TITLE
[AGE-456] When creating Salesforce case from Slack, should be able to select project/service from dropdown

### DIFF
--- a/tiger_agent/agent/tiger_agent.py
+++ b/tiger_agent/agent/tiger_agent.py
@@ -305,6 +305,40 @@ class TigerAgent:
             extra_ctx: Dictionary of BaseModel objects keyed by name for template access
         """
 
+    async def handle_create_salesforce_case(
+        self,
+        hctx: HarnessContext,
+        event: SalesforceCreateNewCaseEvent,
+        channel_to_respond: str,
+    ) -> None:
+        account_id_for_channel = await get_salesforce_account_id_for_channel(
+            pool=hctx.pool, channel_id=channel_to_respond
+        )
+
+        if not account_id_for_channel:
+            logfire.warn(
+                "Skipping Salesforce case creation. No Salesforce account associated with the channel.",
+                channel=channel_to_respond,
+                user=event.user,
+            )
+            return
+
+        new_case = create_case(
+            salesforce_client=hctx.salesforce_client,
+            subject=event.subject,
+            description=event.description,
+            severity=event.severity,
+            account_id=account_id_for_channel,
+            project_id=event.project_id,
+            service_id=event.service_id,
+        )
+        await post_response(
+            client=hctx.app.client,
+            channel=channel_to_respond,
+            thread_ts=None,
+            text=f"*Support Case Created*\nCase Number: {new_case.CaseNumber}\nSubject: {new_case.Subject} \nDescription: {new_case.Description}",
+        )
+
     async def handle_salesforce_event(
         self,
         hctx: HarnessContext,
@@ -377,7 +411,7 @@ class TigerAgent:
 
         return message_to_link_to
 
-    async def handle_slack_mention(
+    async def handle_slack_event(
         self,
         hctx: HarnessContext,
         event: SlackAppMentionEvent | SlackMessageEvent,
@@ -476,32 +510,11 @@ class TigerAgent:
         )
 
         if isinstance(event, SalesforceCreateNewCaseEvent):
-            account_id_for_channel = await get_salesforce_account_id_for_channel(
-                pool=hctx.pool, channel_id=channel_to_respond
+            await self.handle_create_salesforce_case(
+                hctx=hctx,
+                event=event,
+                channel_to_respond=channel_to_respond,
             )
-
-            if not account_id_for_channel:
-                logfire.warn(
-                    "Skipping Salesforce case creation. No Salesforce account associated with the channel.",
-                    channel=channel_to_respond,
-                    user=event.user,
-                )
-                return
-
-            new_case = create_case(
-                salesforce_client=hctx.salesforce_client,
-                subject=event.subject,
-                description=event.description,
-                severity=event.severity,
-                account_id=account_id_for_channel,
-            )
-            await post_response(
-                client=hctx.app.client,
-                channel=channel_to_respond,
-                thread_ts=None,
-                text=f"*Support Case Created*\nCase Number: {new_case.CaseNumber}\nSubject: {new_case.Subject} \nDescription: {new_case.Description}",
-            )
-
             return
 
         agent_and_ctx, self.bot_info = await create_agent_and_context(
@@ -532,7 +545,7 @@ class TigerAgent:
                 channel_to_respond=channel_to_respond,
             )
 
-        return await self.handle_slack_mention(
+        return await self.handle_slack_event(
             hctx=hctx,
             event=event,
             agent=agent,

--- a/tiger_agent/events/slack.py
+++ b/tiger_agent/events/slack.py
@@ -20,6 +20,7 @@ from tiger_agent.salesforce.types import (
     AgentFeedbackRatingEvent,
     SalesforceCreateNewCaseEvent,
 )
+from tiger_agent.salesforce.utils import get_services_for_account
 from tiger_agent.slack.commands import (
     handle_command,
 )
@@ -139,10 +140,15 @@ class SlackEventHandler:
             )
             return
 
+        services_and_projects = get_services_for_account(
+            self._hctx.salesforce_client, salesforce_account_id_for_channel
+        )
+
         await send_new_salesforce_case_workflow_form(
             client=self._hctx.app.client,
             channel=slack_command.channel_id,
             user=slack_command.user_id,
+            services=services_and_projects,
         )
 
         respond()
@@ -200,6 +206,19 @@ class SlackEventHandler:
 
         user = (body.get("user") or {}).get("id")
         channel = (body.get("channel") or {}).get("id")
+        service_id: str | None = None
+        project_id: str | None = None
+        maybe_project_and_service = form_data.get("service")
+
+        if maybe_project_and_service:
+            # we can get either "<project id>" or "<project id>|<service id>"
+            items = maybe_project_and_service.split("|")
+            if len(items) == 1:
+                project_id = items[0]
+            elif len(items) == 2:
+                project_id = items[0]
+                service_id = items[1]
+
         if not user or not channel:
             logfire.error(
                 "Could not determine user or channel from new Salesforce case form submission",
@@ -215,6 +234,8 @@ class SlackEventHandler:
                 user=user,
                 channel=channel,
                 severity="Severity 3 - Medium",  # for now, this will be hardcoded
+                project_id=project_id,
+                service_id=service_id,
             ).model_dump(),
         )
         await self._trigger.put(True)

--- a/tiger_agent/salesforce/types.py
+++ b/tiger_agent/salesforce/types.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 import logfire
 from pydantic import BaseModel
 
@@ -79,6 +81,8 @@ class SalesforceCreateNewCaseEvent(SalesforceBaseEvent):
     user: str
     channel: str
     severity: str
+    project_id: str | None
+    service_id: str | None
 
 
 class SalesforceAssignmentChangedEvent(SalesforceBaseEvent):
@@ -97,3 +101,9 @@ class AgentFeedbackRatingEvent(BaseModel):
     message_ts: str
     channel: str
     rating: int
+
+
+@dataclass
+class ServiceRecord:
+    service_id: str
+    project_id: str | None

--- a/tiger_agent/salesforce/utils.py
+++ b/tiger_agent/salesforce/utils.py
@@ -18,7 +18,7 @@ from tiger_agent.salesforce.constants import (
     CASE_FIELDS,
     SALESFORCE_DOMAIN,
 )
-from tiger_agent.salesforce.types import CaseData, SalesforceBaseEvent
+from tiger_agent.salesforce.types import CaseData, SalesforceBaseEvent, ServiceRecord
 
 RECONNECT_DELAY_SECONDS = 30
 IGNORED_CONTACT_EMAILS = set(
@@ -183,6 +183,8 @@ def create_case(
     description: str,
     severity: str,
     account_id: str,
+    project_id: str | None = None,
+    service_id: str | None = None,
 ) -> CaseData:
     payload = {
         "Subject": subject,
@@ -190,9 +192,41 @@ def create_case(
         "Severity__c": severity,
         "AccountId": account_id,
     }
+    if project_id:
+        payload["Cloud_Project_ID__c"] = project_id
+    if service_id:
+        payload["Cloud_Service_ID__c"] = service_id
     result = salesforce_client.Case.create(payload)
     if not result["success"] or not result["id"]:
         logfire.error("Could not create a new salesforce case")
         return
     case = salesforce_client.Case.get(result["id"])
     return CaseData(**case)
+
+
+def get_services_for_account(
+    salesforce_client: Salesforce, account_id: str
+) -> list[ServiceRecord] | None:
+    result = salesforce_client.query(
+        f"SELECT Name, Project_Id__c FROM Service__c WHERE Account__c = '{account_id}'"
+    )
+    records = result.get("records", [])
+    if not records:
+        return None
+    return [
+        ServiceRecord(service_id=r["Name"], project_id=r.get("Project_Id__c"))
+        for r in records
+        if r.get("Name")
+    ]
+
+
+def get_project_ids_for_account(
+    salesforce_client: Salesforce, account_id: str
+) -> list[str] | None:
+    result = salesforce_client.query(
+        f"SELECT Project_Id__c FROM Project__c WHERE Account__c = '{account_id}'"
+    )
+    records = result.get("records", [])
+    if not records:
+        return None
+    return [r["Project_Id__c"] for r in records if r.get("Project_Id__c")]

--- a/tiger_agent/slack/utils.py
+++ b/tiger_agent/slack/utils.py
@@ -39,6 +39,7 @@ from slack_sdk.web.async_client import (
     AsyncWebClient,
 )
 
+from tiger_agent.salesforce.types import ServiceRecord
 from tiger_agent.slack.constants import (
     AGENT_FEEDBACK_RATING,
     CONFIRM_PROACTIVE_PROMPT,
@@ -762,6 +763,7 @@ async def send_new_salesforce_case_workflow_form(
     client: AsyncWebClient,
     channel: str,
     user: str,
+    services: list[ServiceRecord] | None,
 ):
     """Send an ephemeral message with a form to collect new Salesforce case details.
 
@@ -770,63 +772,105 @@ async def send_new_salesforce_case_workflow_form(
         channel: Slack channel ID to post the form in
         user: Slack user ID to send the ephemeral message to
     """
+
+    service_options = []
+    if services:
+        seen_projects: set[str] = set()
+        for s in services:
+            if s.project_id and s.project_id not in seen_projects:
+                seen_projects.add(s.project_id)
+                service_options.append(
+                    {
+                        "text": {"type": "plain_text", "text": f"Project: {s.project_id}"},
+                        "value": s.project_id,
+                    }
+                )
+        for s in services:
+            label = f"Project: {s.project_id}, Service: {s.service_id}"
+            value = f"{s.project_id}|{s.service_id}"
+            service_options.append(
+                {
+                    "text": {"type": "plain_text", "text": label},
+                    "value": value,
+                }
+            )
+
+    service_block = (
+        {
+            "type": "input",
+            "block_id": "service_block",
+            "label": {"type": "plain_text", "text": "Service"},
+            "element": {
+                "type": "static_select",
+                "action_id": "service_select",
+                "placeholder": {"type": "plain_text", "text": "Select a service"},
+                "options": service_options,
+            },
+        }
+        if service_options
+        else None
+    )
+
+    blocks = [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*New Support Case*\nPlease fill out the details below.",
+            },
+        },
+        {
+            "type": "input",
+            "block_id": "subject_block",
+            "label": {"type": "plain_text", "text": "Title"},
+            "element": {
+                "type": "plain_text_input",
+                "action_id": "subject_input",
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "Brief summary of the case",
+                },
+                "max_length": 200,
+            },
+        },
+        {
+            "type": "input",
+            "block_id": "description_block",
+            "label": {"type": "plain_text", "text": "Description"},
+            "element": {
+                "type": "plain_text_input",
+                "action_id": "description_input",
+                "multiline": True,
+                "placeholder": {
+                    "type": "plain_text",
+                    "text": "Detailed description of the issue",
+                },
+            },
+        },
+        *([service_block] if service_block else []),
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "action_id": NEW_SALESFORCE_CASE_WORKFLOW_FORM_SUBMIT,
+                    "style": "primary",
+                    "text": {"type": "plain_text", "text": "Submit"},
+                },
+                {
+                    "type": "button",
+                    "action_id": NEW_SALESFORCE_CASE_WORKFLOW_FORM_CANCEL,
+                    "text": {"type": "plain_text", "text": "Cancel"},
+                },
+            ],
+        },
+    ]
+
     await client.chat_postEphemeral(
         channel=channel,
         user=user,
         text="New Support Case",
-        blocks=[
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "*New Support Case*\nPlease fill out the details below.",
-                },
-            },
-            {
-                "type": "input",
-                "block_id": "subject_block",
-                "label": {"type": "plain_text", "text": "Title"},
-                "element": {
-                    "type": "plain_text_input",
-                    "action_id": "subject_input",
-                    "placeholder": {
-                        "type": "plain_text",
-                        "text": "Brief summary of the case",
-                    },
-                    "max_length": 200,
-                },
-            },
-            {
-                "type": "input",
-                "block_id": "description_block",
-                "label": {"type": "plain_text", "text": "Description"},
-                "element": {
-                    "type": "plain_text_input",
-                    "action_id": "description_input",
-                    "multiline": True,
-                    "placeholder": {
-                        "type": "plain_text",
-                        "text": "Detailed description of the issue",
-                    },
-                },
-            },
-            {
-                "type": "actions",
-                "elements": [
-                    {
-                        "type": "button",
-                        "action_id": NEW_SALESFORCE_CASE_WORKFLOW_FORM_SUBMIT,
-                        "style": "primary",
-                        "text": {"type": "plain_text", "text": "Submit"},
-                    },
-                    {
-                        "type": "button",
-                        "action_id": NEW_SALESFORCE_CASE_WORKFLOW_FORM_CANCEL,
-                        "text": {"type": "plain_text", "text": "Cancel"},
-                    },
-                ],
-            },
-        ],
+        blocks=blocks,
     )
 
 
@@ -862,6 +906,12 @@ async def handle_new_salesforce_case_workflow_form_submit(
         .get("description_input", {})
         .get("value")
     )
+    service_value = (
+        state_values.get("service_block", {})
+        .get("service_select", {})
+        .get("selected_option", {})
+        or {}
+    ).get("value")
 
     if not subject or not description:
         logfire.error(
@@ -876,7 +926,7 @@ async def handle_new_salesforce_case_workflow_form_submit(
         subject=subject,
     )
 
-    return {"subject": subject, "description": description}
+    return {"subject": subject, "description": description, "service": service_value}
 
 
 async def handle_new_salesforce_case_workflow_form_cancel(

--- a/tiger_agent/slack/utils.py
+++ b/tiger_agent/slack/utils.py
@@ -771,20 +771,28 @@ async def send_new_salesforce_case_workflow_form(
         client: Slack AsyncWebClient for API calls
         channel: Slack channel ID to post the form in
         user: Slack user ID to send the ephemeral message to
+        services: List of project/services id associated with account
     """
 
     service_options = []
     if services:
+        # let's get a unique set of projects with the service+project items
+        # so that the user can just select a project, rather than
+        # tying support case to a specific service within a project
         seen_projects: set[str] = set()
         for s in services:
             if s.project_id and s.project_id not in seen_projects:
                 seen_projects.add(s.project_id)
                 service_options.append(
                     {
-                        "text": {"type": "plain_text", "text": f"Project: {s.project_id}"},
+                        "text": {
+                            "type": "plain_text",
+                            "text": f"Project: {s.project_id}",
+                        },
                         "value": s.project_id,
                     }
                 )
+        # then create options for each service within each project
         for s in services:
             label = f"Project: {s.project_id}, Service: {s.service_id}"
             value = f"{s.project_id}|{s.service_id}"


### PR DESCRIPTION
## What
This fetches all projects/services from the account associated with the channel in which `/support` is called from and adds them to a drop down on the new case form:

![2026-04-10 13 31 08](https://github.com/user-attachments/assets/21447359-ffe4-4549-84e4-cee096a7e35c)

## Why
So we have as much info as possible when creating new cases in Salesforce.