### PR TITLE
[AGE-459] add admin commands to set channel <-> salesforce account relationship

### DIFF
--- a/tiger_agent/db/utils.py
+++ b/tiger_agent/db/utils.py
@@ -99,6 +99,28 @@ async def get_salesforce_account_id_for_channel(
         return row[0] if row else None
 
 
+async def upsert_salesforce_account_id_for_channel(
+    pool: AsyncConnectionPool, channel_id: str, salesforce_account_id: str
+) -> None:
+    async with pool.connection() as con:
+        await con.execute(
+            """INSERT INTO agent.customer_channel_salesforce_link (channel_id, salesforce_account_id)
+               VALUES (%s, %s)
+               ON CONFLICT (channel_id) DO UPDATE SET salesforce_account_id = EXCLUDED.salesforce_account_id""",
+            (channel_id, salesforce_account_id),
+        )
+
+
+async def remove_salesforce_account_id_for_channel(
+    pool: AsyncConnectionPool, channel_id: str
+) -> None:
+    async with pool.connection() as con:
+        await con.execute(
+            "DELETE FROM agent.customer_channel_salesforce_link WHERE channel_id = %s",
+            (channel_id,),
+        )
+
+
 @logfire.instrument("insert_event", extract_args=False)
 async def insert_event(pool: AsyncConnectionPool, event: dict[str, Any]) -> None:
     """Insert a Slack/Salesforce event into the database work queue.

--- a/tiger_agent/slack/commands.py
+++ b/tiger_agent/slack/commands.py
@@ -6,7 +6,12 @@ from dataclasses import dataclass, field
 
 import logfire
 
-from tiger_agent.db.utils import insert_event, user_is_admin
+from tiger_agent.db.utils import (
+    insert_event,
+    remove_salesforce_account_id_for_channel,
+    upsert_salesforce_account_id_for_channel,
+    user_is_admin,
+)
 from tiger_agent.events.types import HarnessContext
 from tiger_agent.salesforce.constants import (
     SALESFORCE_CASE_CHANNEL,
@@ -242,6 +247,31 @@ async def handle_admins_list_command(ctx: CommandContext, _: list[str]) -> str:
         return f"Current admin users ({len(user_list)}):\n" + "\n".join(user_list)
 
 
+async def handle_salesforce_add_customer_channel_command(
+    ctx: CommandContext, args: list[str]
+) -> str:
+    [channel_id, salesforce_account_id] = args
+    await upsert_salesforce_account_id_for_channel(
+        ctx.hctx.pool,
+        channel_id=channel_id,
+        salesforce_account_id=salesforce_account_id,
+    )
+
+    return f"Assigned channel {channel_id} to Salesforce account id {salesforce_account_id}"
+
+
+async def handle_salesforce_remove_customer_channel_command(
+    ctx: CommandContext, args: list[str]
+) -> str:
+    [channel_id] = args
+    await remove_salesforce_account_id_for_channel(
+        ctx.hctx.pool,
+        channel_id=channel_id,
+    )
+
+    return f"Removed Salesforce channel {channel_id}"
+
+
 async def handle_salesforce_create_notification_command(
     ctx: CommandContext, args: list[str]
 ) -> str:
@@ -306,6 +336,21 @@ def _build_command_handlers() -> CommandGroup:
                             key="create-notification",
                             expected_parameters=1,
                             func=handle_salesforce_create_notification_command,
+                        ),
+                        CommandGroup(
+                            key="customer-channel",
+                            commands=[
+                                Command(
+                                    "add",
+                                    expected_parameters=2,
+                                    func=handle_salesforce_add_customer_channel_command,
+                                ),
+                                Command(
+                                    "remove",
+                                    expected_parameters=1,
+                                    func=handle_salesforce_remove_customer_channel_command,
+                                ),
+                            ],
                         ),
                     ],
                 ),


### PR DESCRIPTION
## What
adds 
* `/eon salesforce customer-channel add <channel id> <salesforce account id>`
* `/eon salesforce customer-channel remove <channel id>`