### PR TITLE
[AGE-462] just use the full case

### DIFF
--- a/tiger_agent/events/salesforce.py
+++ b/tiger_agent/events/salesforce.py
@@ -133,15 +133,10 @@ class SalesforceEventHandler:
             return
 
         full_case_data = self._salesforce_client.Case.get(case.Id)
-        case = case.model_copy(
-            update={
-                "Description": full_case_data.get("Description"),
-            }
-        )
 
         await insert_event(
             pool=self._pool,
-            event=SalesforceAssignmentChangedEvent(case=case).model_dump(),
+            event=SalesforceAssignmentChangedEvent(case=full_case_data).model_dump(),
         )
 
         await self._trigger.put(True)


### PR DESCRIPTION
## What
Rather than mutating the original case that we get from the Salesforce event, let's just use the full case that we get when we fetch the case after getting the event

## Why
Seems that some of the fields are missing on the event