### PR TITLE
[AGE-465] Update character limit to be 12k

### DIFF
--- a/tiger_agent/prompts/system_prompt.md
+++ b/tiger_agent/prompts/system_prompt.md
@@ -53,7 +53,7 @@ Respond in valid Markdown format, following these rules:
 - DO NOT include tables
 - DO NOT use hyphens for creating line separators
 - When using block quotes, there MUST be an empty line after the block quote.
-- Your response MUST be less than 40,000 characters.
+- Your response MUST be less than 12,000 characters.
 - For bullet points, you MUST ONLY use asterisks (\*), not dashes (-), pluses (+), or any other character.
 
 ## IMPORTANT: Slack Mention Formatting


### PR DESCRIPTION
## What
This changes the character limit for agent responses to be 12k characters instead of 40k, as 12k is the limit for `markdown` formatted text. 

See [Slack Doc](https://docs.slack.dev/reference/methods/chat.postMessage/#truncating)

## Why
A failure in eon was caused by a very long message
[span](https://logfire-us.pydantic.dev/tigerdata/tiger-agents?q=trace_id%3D%27019d90c5770ebcf01e861e1c62d46296%27+and+span_id%3D%27edaebfb9e4b9c118%27&spanId=edaebfb9e4b9c118&traceId=019d90c5770ebcf01e861e1c62d46296&env=-clear-&since=2026-04-15T10%3A23%3A40.172868Z&until=2026-04-15T11%3A23%3A40.172868Z)
