### PR TITLE
[AGE-476] When a Slack thread is synced to Salesforce case, include attachments

### DIFF
--- a/tiger_agent/events/slack.py
+++ b/tiger_agent/events/slack.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from typing import Any
 
 import logfire
+from pydantic_ai.messages import BinaryContent
 from slack_bolt.adapter.socket_mode.websockets import AsyncSocketModeHandler
 from slack_bolt.context.ack.async_ack import AsyncAck
 from slack_bolt.context.respond.async_respond import AsyncRespond
@@ -27,6 +28,7 @@ from tiger_agent.salesforce.types import (
     SalesforceCreateNewCaseEvent,
 )
 from tiger_agent.salesforce.utils import (
+    EmailAttachment,
     add_case_email_comment,
     get_services_for_account,
 )
@@ -43,6 +45,7 @@ from tiger_agent.slack.constants import (
 )
 from tiger_agent.slack.types import BotInfo, SlackCommand, UserInfo
 from tiger_agent.slack.utils import (
+    download_private_file,
     fetch_bot_info,
     fetch_team_info,
     fetch_user_info,
@@ -159,6 +162,7 @@ class SlackEventHandler:
         event["subtype"] = event["channel_type"]
         channel = event.get("channel")
         thread_ts = event.get("thread_ts")
+        files = event.get("files", [])
 
         # if the message was in an im to the agent, respond (even though agent was not mentioned)
         if event["subtype"] in ("im"):
@@ -187,6 +191,26 @@ class SlackEventHandler:
                         user_info
                     )
 
+                    attachments: list[EmailAttachment] = []
+
+                    for file in files:
+                        type = file.get("mimetype")
+                        url = file.get("url_private_download")
+                        name = file.get("name")
+
+                        file_content = await download_private_file(
+                            url_private_download=url,
+                            slack_bot_token=self._hctx.slack_bot_token,
+                        )
+                        if isinstance(file_content, BinaryContent):
+                            attachments.append(
+                                EmailAttachment(
+                                    name=name,
+                                    body=file_content.data,
+                                    content_type=type,
+                                )
+                            )
+
                     # for internal users, we will set the
                     # from address and the display name (real name from Slack) + an envvar for internal user suffix
                     # but for external users, we just display the email address
@@ -204,6 +228,7 @@ class SlackEventHandler:
                         from_name=f"{user_info.real_name} ({SALESFORCE_INTERNAL_FROM_NAME_SUFFIX})"
                         if not user_is_external
                         else None,
+                        attachments=attachments if attachments else None,
                     )
 
                     logfire.info(

--- a/tiger_agent/salesforce/utils.py
+++ b/tiger_agent/salesforce/utils.py
@@ -1,6 +1,8 @@
 import asyncio
+import base64
 import os
 from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
 from typing import Any
 
 import logfire
@@ -223,6 +225,13 @@ def get_services_for_account(
     ]
 
 
+@dataclass
+class EmailAttachment:
+    name: str
+    body: bytes
+    content_type: str
+
+
 def add_case_email_comment(
     salesforce_client: Salesforce,
     case_id: str,
@@ -233,6 +242,7 @@ def add_case_email_comment(
     from_name: str | None = None,
     incoming: bool = True,
     html_body: str | None = None,
+    attachments: list[EmailAttachment] | None = None,
 ) -> None:
     payload = {
         "ParentId": case_id,
@@ -250,6 +260,24 @@ def add_case_email_comment(
         logfire.error(
             "Could not add email comment to Salesforce case", extra={"case_id": case_id}
         )
+        return
+
+    email_message_id = result["id"]
+    for attachment in attachments or []:
+        encoded = base64.b64encode(attachment.body).decode("utf-8")
+        att_result = salesforce_client.Attachment.create(
+            {
+                "ParentId": email_message_id,
+                "Name": attachment.name,
+                "ContentType": attachment.content_type,
+                "Body": encoded,
+            }
+        )
+        if not att_result["success"] or not att_result["id"]:
+            logfire.error(
+                "Could not attach file to Salesforce email message",
+                extra={"email_message_id": email_message_id, "name": attachment.name},
+            )
 
 
 def get_project_ids_for_account(


### PR DESCRIPTION
## What
Any attachments in Slack thread messages should be included in the sync to Salesforce

## Example
<img width="410" height="275" alt="image" src="https://github.com/user-attachments/assets/f54d7b0b-4254-49bb-b01f-95501cc6c1ae" />
