### PR TITLE
[AGE-470] Make the polling logs and intercepted http logs `trace` level

### DIFF
--- a/tiger_agent/db/utils.py
+++ b/tiger_agent/db/utils.py
@@ -162,6 +162,7 @@ async def insert_handled_event(pool: AsyncConnectionPool, event: dict[str, Any])
         return result[0] if result else None
 
 
+@logfire.instrument("claim_event", extract_args=False, level="trace")
 async def claim_event(
     pool: AsyncConnectionPool, max_attempts: int = 3, invisibility_minutes: int = 10
 ) -> Event | None:
@@ -279,6 +280,7 @@ async def get_salesforce_case_thread_case_id(
         return row[0] if row else None
 
 
+@logfire.instrument("delete_expired_events", extract_args=False, level="trace")
 async def delete_expired_events(
     pool: AsyncConnectionPool, max_attempts: int = 3, max_age_minutes: int = 60
 ) -> None:

--- a/tiger_agent/utils.py
+++ b/tiger_agent/utils.py
@@ -17,7 +17,9 @@ import os
 from logging.config import dictConfig
 from typing import Any
 
+import httpx
 import logfire
+from opentelemetry.trace import Span
 from psycopg.types.json import Jsonb
 from pydantic import BaseModel
 from pydantic_ai import RunContext
@@ -66,11 +68,17 @@ def setup_logging(service_name: str = "tiger-agent") -> None:
             service_version=__version__,
         )
 
+        def _set_httpx_trace_level(span: Span, request: httpx.Request) -> None:
+            span.set_attribute("logfire.level_num", 1)  # trace
+
         # Set up all the logfire instrumentation
         logfire.instrument_psycopg()  # Database query tracing
         logfire.instrument_pydantic_ai()  # AI model interaction tracing
         logfire.instrument_mcp()  # MCP server communication tracing
-        logfire.instrument_httpx(capture_headers=True)  # HTTP client request tracing
+        logfire.instrument_httpx(
+            capture_headers=True,
+            request_hook=_set_httpx_trace_level,
+        )  # HTTP client request tracing
         logfire.instrument_system_metrics(
             {
                 "process.cpu.time": ["user", "system"],


### PR DESCRIPTION
## What

makes some logs trace level


No need to see this
<img width="1111" height="817" alt="image" src="https://github.com/user-attachments/assets/6d23b94b-c703-4308-8de8-a421b714b862" />

Or 
<img width="1121" height="974" alt="image" src="https://github.com/user-attachments/assets/ca20c7a6-4847-414f-a16f-fda75cc281d4" />
