### PR TITLE
[AGE-468] Sync Salesforce `FeedItem` to Slack case thread

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "click>=8.3.0",
     "jinja2>=3.1.6",
     "logfire[httpx,psycopg,system-metrics]>=4.10.0",
-    "html-to-markdown>=3.2.6",
+    "html-slacker",
     "psycopg[binary,pool]>=3.2.10",
     "pydantic-ai>=1.28.0",
     "python-dotenv[cli]>=1.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "click>=8.3.0",
     "jinja2>=3.1.6",
     "logfire[httpx,psycopg,system-metrics]>=4.10.0",
+    "html-to-markdown>=3.2.6",
     "psycopg[binary,pool]>=3.2.10",
     "pydantic-ai>=1.28.0",
     "python-dotenv[cli]>=1.1.1",

--- a/tiger_agent/agent/tiger_agent.py
+++ b/tiger_agent/agent/tiger_agent.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Any
 
 import logfire
+from html_to_markdown import convert
 from jinja2 import ChoiceLoader, Environment, FileSystemLoader, PackageLoader
 from pydantic import BaseModel
 from pydantic_ai import Agent, UsageLimits, models
@@ -42,6 +43,7 @@ from tiger_agent.agent.utils import create_agent_and_context
 from tiger_agent.db.utils import (
     add_salesforce_case_thread,
     get_salesforce_account_id_for_channel,
+    get_salesforce_case_thread_thread_id,
     usage_limit_reached,
     user_ignored,
 )
@@ -58,6 +60,7 @@ from tiger_agent.salesforce.constants import (
 from tiger_agent.salesforce.types import (
     SalesforceBaseEvent,
     SalesforceCreateNewCaseEvent,
+    SalesforceFeedItemEvent,
 )
 from tiger_agent.salesforce.utils import create_case, create_case_url
 from tiger_agent.slack.types import (
@@ -306,6 +309,23 @@ class TigerAgent:
             ctx: Agent response context containing event data, user info, and bot info
             extra_ctx: Dictionary of BaseModel objects keyed by name for template access
         """
+
+    async def handle_new_salesforce_case_feed_item(
+        self, hctx: HarnessContext, event: SalesforceFeedItemEvent
+    ):
+        [channel_id, thread_ts] = await get_salesforce_case_thread_thread_id(
+            hctx.pool, case_id=event.feed_item.ParentId
+        )
+
+        # the body from Salesforce is html, let's convert to markdown
+        markdown_conversion = convert(event.feed_item.Body)
+
+        await post_response(
+            client=hctx.app.client,
+            channel=channel_id,
+            thread_ts=thread_ts,
+            text=markdown_conversion.content.strip(),
+        )
 
     async def handle_create_salesforce_case(
         self,
@@ -564,6 +584,10 @@ class TigerAgent:
                 event=event,
                 channel_to_respond=channel_to_respond,
             )
+            return
+
+        if isinstance(event, SalesforceFeedItemEvent):
+            await self.handle_new_salesforce_case_feed_item(hctx=hctx, event=event)
             return
 
         agent_and_ctx, self.bot_info = await create_agent_and_context(

--- a/tiger_agent/agent/tiger_agent.py
+++ b/tiger_agent/agent/tiger_agent.py
@@ -318,12 +318,10 @@ class TigerAgent:
         )
 
         # the body from Salesforce is html, let's convert to markdown
-        markdown_conversion = HTMLSlacker(event.feed_item.Body).get_output()
+        markdown_conversion = HTMLSlacker(event.feed_item.Body).get_output().strip()
 
         body = "\n".join(f"> {line}" for line in markdown_conversion.splitlines())
-        text = (
-            f"_From {event.feed_item.CreatedBy.Name} via Tigerdata Support_\n\n{body}"
-        )
+        text = f"_From_ *{event.feed_item.CreatedBy.Name}* _via Tigerdata Support_\n\n{body}"
 
         await post_response(
             client=hctx.app.client,

--- a/tiger_agent/agent/tiger_agent.py
+++ b/tiger_agent/agent/tiger_agent.py
@@ -310,6 +310,7 @@ class TigerAgent:
             extra_ctx: Dictionary of BaseModel objects keyed by name for template access
         """
 
+    @logfire.instrument("handle_new_salesforce_case_feed_item", extract_args=["event"])
     async def handle_new_salesforce_case_feed_item(
         self, hctx: HarnessContext, event: SalesforceFeedItemEvent
     ):

--- a/tiger_agent/agent/tiger_agent.py
+++ b/tiger_agent/agent/tiger_agent.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import Any
 
 import logfire
-from html_to_markdown import convert
+from htmlslacker import HTMLSlacker
 from jinja2 import ChoiceLoader, Environment, FileSystemLoader, PackageLoader
 from pydantic import BaseModel
 from pydantic_ai import Agent, UsageLimits, models
@@ -318,13 +318,19 @@ class TigerAgent:
         )
 
         # the body from Salesforce is html, let's convert to markdown
-        markdown_conversion = convert(event.feed_item.Body)
+        markdown_conversion = HTMLSlacker(event.feed_item.Body).get_output()
+
+        body = "\n".join(f"> {line}" for line in markdown_conversion.splitlines())
+        text = (
+            f"_From {event.feed_item.CreatedBy.Name} via Tigerdata Support_\n\n{body}"
+        )
 
         await post_response(
             client=hctx.app.client,
             channel=channel_id,
             thread_ts=thread_ts,
-            text=markdown_conversion.content.strip(),
+            text=text,
+            use_mrkdwn=True,
         )
 
     async def handle_create_salesforce_case(

--- a/tiger_agent/agent/types.py
+++ b/tiger_agent/agent/types.py
@@ -8,7 +8,6 @@ from tiger_agent.mcp.types import MCPDict
 from tiger_agent.salesforce.types import (
     SalesforceAssignmentChangedEvent,
     SalesforceCreateNewCaseEvent,
-    SalesforceNewCaseEvent,
 )
 from tiger_agent.slack.types import (
     BotInfo,
@@ -38,7 +37,6 @@ class AgentResponseContext(BaseModel):
     mention: (
         SlackAppMentionEvent
         | SlackMessageEvent
-        | SalesforceNewCaseEvent
         | SalesforceAssignmentChangedEvent
         | SalesforceCreateNewCaseEvent
     )

--- a/tiger_agent/db/utils.py
+++ b/tiger_agent/db/utils.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 
 from tiger_agent.db.constants import PG_MAX_POOL_SIZE
 from tiger_agent.events.types import Event
+from tiger_agent.salesforce.types import SalesforceBaseEvent, SalesforceFeedItem
 
 logger = logging.getLogger(__name__)
 
@@ -85,40 +86,6 @@ async def user_is_admin(pool: AsyncConnectionPool, user_id: str) -> bool:
         )
         row = await result.fetchone()
         return bool(row[0]) if row and row[0] is not None else False
-
-
-async def get_salesforce_account_id_for_channel(
-    pool: AsyncConnectionPool, channel_id: str
-) -> str | None:
-    async with pool.connection() as con:
-        result = await con.execute(
-            "SELECT salesforce_account_id FROM agent.customer_channel_salesforce_link WHERE channel_id = %s",
-            (channel_id,),
-        )
-        row = await result.fetchone()
-        return row[0] if row else None
-
-
-async def upsert_salesforce_account_id_for_channel(
-    pool: AsyncConnectionPool, channel_id: str, salesforce_account_id: str
-) -> None:
-    async with pool.connection() as con:
-        await con.execute(
-            """INSERT INTO agent.customer_channel_salesforce_link (channel_id, salesforce_account_id)
-               VALUES (%s, %s)
-               ON CONFLICT (channel_id) DO UPDATE SET salesforce_account_id = EXCLUDED.salesforce_account_id""",
-            (channel_id, salesforce_account_id),
-        )
-
-
-async def remove_salesforce_account_id_for_channel(
-    pool: AsyncConnectionPool, channel_id: str
-) -> None:
-    async with pool.connection() as con:
-        await con.execute(
-            "DELETE FROM agent.customer_channel_salesforce_link WHERE channel_id = %s",
-            (channel_id,),
-        )
 
 
 @logfire.instrument("insert_event", extract_args=False)
@@ -280,6 +247,18 @@ async def get_salesforce_case_thread_case_id(
         return row[0] if row else None
 
 
+async def get_salesforce_case_thread_thread_id(
+    pool: AsyncConnectionPool, case_id: str
+) -> tuple[str, str] | None:
+    async with pool.connection() as con:
+        result = await con.execute(
+            "SELECT channel_id, thread_ts FROM agent.salesforce_case_thread WHERE case_id = %s",
+            [case_id],
+        )
+        row = await result.fetchone()
+        return (row[0], row[1]) if row else None
+
+
 async def delete_expired_events(
     pool: AsyncConnectionPool, max_attempts: int = 3, max_age_minutes: int = 60
 ) -> None:
@@ -299,3 +278,168 @@ async def delete_expired_events(
                 "select agent.delete_expired_events(%s, %s::int8 * interval '1m')",
                 (max_attempts, max_age_minutes),
             )
+
+
+@logfire.instrument("is_case_assignment_new", extract_args=False)
+async def is_case_assignment_new(
+    pool: AsyncConnectionPool, case_id: str, owner_id: str
+) -> bool:
+    """
+    Verifies if the Salesforce case assignment is new e.g. if the assigned user (owner) has actually changed.
+    This is done by reading the event and event_hist table for the most recent event for that case
+
+
+    Args:
+        case_id: The ID of the Salesforce case
+        owner_id: The ID of the assignee
+
+    Returns:
+        True if the given owner id is different from the most recently processed/unprocessed
+        Salesforce event
+    """
+    async with (
+        pool.connection() as con,
+        con.cursor(row_factory=dict_row) as cur,
+    ):
+        result = await cur.execute(
+            """select * from agent.event
+                WHERE
+                    event->>'type' = 'salesforce_event'
+                    AND event->>'subtype' = 'new_assignee'
+                    AND event->'case'->>'Id' = %s
+                    order by event_ts desc limit 1;""",
+            (case_id,),
+        )
+        current_row: dict[str, Any] | None = await result.fetchone()
+
+        if current_row:
+            try:
+                event = Event(**current_row)
+
+                # there is an unprocessed new_assignee event
+                # that has the same owner
+                if (
+                    isinstance(event.event, SalesforceBaseEvent)
+                    and event.event.case.OwnerId == owner_id
+                ):
+                    return False
+            except ValidationError as e:
+                logfire.error(
+                    "failed to parse historical event",
+                    exc_info=e,
+                    extra={"row": current_row},
+                )
+
+        result = await cur.execute(
+            """select * from agent.event_hist 
+                WHERE
+                    event->>'type' = 'salesforce_event'
+                    AND event->>'subtype' = 'new_assignee'
+                    AND event->'case'->>'Id' = %s
+                    order by event_ts desc limit 1;""",
+            (case_id,),
+        )
+        processed_row: dict[str, Any] | None = await result.fetchone()
+        if processed_row:
+            try:
+                event = Event(**processed_row)
+
+                # there is an processed new_assignee event
+                # that has the same owner
+                if (
+                    isinstance(event.event, SalesforceBaseEvent)
+                    and event.event.case.OwnerId == owner_id
+                ):
+                    return False
+            except ValidationError as e:
+                logfire.error(
+                    "failed to parse historical event",
+                    exc_info=e,
+                    extra={"row": processed_row},
+                )
+
+        return True
+
+
+async def get_salesforce_account_id_for_channel(
+    pool: AsyncConnectionPool, channel_id: str
+) -> str | None:
+    async with pool.connection() as con:
+        result = await con.execute(
+            "SELECT salesforce_account_id FROM agent.customer_channel_salesforce_link WHERE channel_id = %s",
+            (channel_id,),
+        )
+        row = await result.fetchone()
+        return row[0] if row else None
+
+
+async def upsert_salesforce_account_id_for_channel(
+    pool: AsyncConnectionPool, channel_id: str, salesforce_account_id: str
+) -> None:
+    async with pool.connection() as con:
+        await con.execute(
+            """INSERT INTO agent.customer_channel_salesforce_link (channel_id, salesforce_account_id)
+               VALUES (%s, %s)
+               ON CONFLICT (channel_id) DO UPDATE SET salesforce_account_id = EXCLUDED.salesforce_account_id""",
+            (channel_id, salesforce_account_id),
+        )
+
+
+async def remove_salesforce_account_id_for_channel(
+    pool: AsyncConnectionPool, channel_id: str
+) -> None:
+    async with pool.connection() as con:
+        await con.execute(
+            "DELETE FROM agent.customer_channel_salesforce_link WHERE channel_id = %s",
+            (channel_id,),
+        )
+
+
+async def filter_new_feed_items(
+    pool: AsyncConnectionPool, feed_items: list[SalesforceFeedItem]
+) -> list[SalesforceFeedItem]:
+    """Return only feed items that correlate to a tracked Slack thread and have not already been processed."""
+    if not feed_items:
+        return []
+
+    # first, filter to only feed items whose ParentId has a matching case_id
+    # in the salesforce_case_thread table (i.e. cases we are actively tracking)
+    parent_ids = list({item.ParentId for item in feed_items if item.ParentId})
+    async with pool.connection() as con:
+        result = await con.execute(
+            "SELECT DISTINCT case_id FROM agent.salesforce_case_thread WHERE case_id = ANY(%s)",
+            (parent_ids,),
+        )
+        tracked_case_ids = {row[0] for row in await result.fetchall()}
+
+    feed_items = [item for item in feed_items if item.ParentId in tracked_case_ids]
+    if not feed_items:
+        return []
+
+    items_json = Jsonb(
+        [{"id": item.Id, "created_date": item.CreatedDate} for item in feed_items]
+    )
+
+    def get_already_handled_query(table_name: str) -> str:
+        return f"""
+            SELECT elem->>'id' AS id
+            FROM jsonb_array_elements(%s::jsonb) AS elem
+            WHERE EXISTS (
+                SELECT 1 FROM agent.{table_name}
+                WHERE event_ts = (elem->>'created_date')::timestamptz
+                  AND event->>'type' = 'salesforce_event'
+                  AND event->>'subtype' = 'new_feed_item'
+                  AND event->'feed_item'->>'Id' = elem->>'id'
+            )
+        """
+
+    async with pool.connection() as con:
+        result = await con.execute(get_already_handled_query("event"), [items_json])
+        existing_ids = {row[0] for row in await result.fetchall()}
+
+        result = await con.execute(
+            get_already_handled_query("event_hist"), [items_json]
+        )
+        existing_ids |= {row[0] for row in await result.fetchall()}
+
+    return [item for item in feed_items if item.Id not in existing_ids]

--- a/tiger_agent/events/salesforce.py
+++ b/tiger_agent/events/salesforce.py
@@ -20,7 +20,6 @@ from tiger_agent.salesforce.types import (
     SalesforceAssignmentChangedEvent,
     SalesforceFeedItem,
     SalesforceFeedItemEvent,
-    SalesforceNewCaseEvent,
 )
 from tiger_agent.salesforce.utils import (
     should_ignore_new_case,
@@ -92,34 +91,6 @@ class SalesforceEventHandler:
             result = self._salesforce_client.PushTopic.create(topic_config)
             logfire.info("PushTopic created", extra={"id": result["id"]})
 
-    @logfire.instrument("handle_new_case", extract_args=["case"])
-    async def handle_new_case(self, case: CaseData):
-        if not SALESFORCE_CASE_CHANNEL:
-            logfire.warn(
-                "A new case was created, but no Slack channel configured",
-                extra={"case": case.model_dump_json()},
-            )
-            return
-        if case.Status == "Spam":
-            logfire.info("Ignoring case flagged as spam")
-            return
-
-        if should_ignore_new_case(case):
-            logfire.info("Ignoring case")
-            return
-
-        full_case_data = self._salesforce_client.Case.get(case.Id)
-        case = case.model_copy(
-            update={"Description": full_case_data.get("Description")}
-        )
-
-        await insert_event(
-            pool=self._pool,
-            event=SalesforceNewCaseEvent(case=case).model_dump(),
-        )
-
-        await self._trigger.put(True)
-
     async def _run_schedule(self):
         while True:
             schedule.run_pending()
@@ -127,6 +98,13 @@ class SalesforceEventHandler:
 
     @logfire.instrument("handle_updated_case_assignee", extract_args=["case"])
     async def handle_updated_case_assignee(self, case: CaseData):
+        if not SALESFORCE_CASE_CHANNEL:
+            logfire.warn(
+                "A new case was created, but no Slack channel configured",
+                extra={"case": case.model_dump_json()},
+            )
+            return
+
         if not case.Owner.Email:
             # no user assigned yet
             logfire.info("Ignoring event, no user assigned to case")
@@ -134,6 +112,10 @@ class SalesforceEventHandler:
 
         if case.Status != "New":
             logfire.info("Ignoring case event as status is not new")
+            return
+
+        if should_ignore_new_case(case):
+            logfire.info("Ignoring case")
             return
 
         if not await is_case_assignment_new(

--- a/tiger_agent/events/salesforce.py
+++ b/tiger_agent/events/salesforce.py
@@ -1,14 +1,15 @@
 import asyncio
 from asyncio import TaskGroup
+from datetime import datetime
 
 import logfire
 import schedule
 from simple_salesforce.api import Salesforce
 
-from tiger_agent.db.utils import insert_event
+from tiger_agent.db.utils import insert_event, is_case_assignment_new
 from tiger_agent.events.types import HarnessContext
+from tiger_agent.salesforce.case_feed_item_poller import SalesforceCaseFeedItemPoller
 from tiger_agent.salesforce.constants import (
-    CASE_FIELDS,
     CASE_ID_FIELD,
     CASE_OWNER_ID_FIELD,
     SALESFORCE_CASE_CHANNEL,
@@ -17,10 +18,11 @@ from tiger_agent.salesforce.new_case_poller import SalesforceNewCasePoller
 from tiger_agent.salesforce.types import (
     CaseData,
     SalesforceAssignmentChangedEvent,
+    SalesforceFeedItem,
+    SalesforceFeedItemEvent,
     SalesforceNewCaseEvent,
 )
 from tiger_agent.salesforce.utils import (
-    is_case_assignment_new,
     should_ignore_new_case,
     subscribe_to_topic,
 )
@@ -32,6 +34,7 @@ class SalesforceEventHandler:
         self._pool = hctx.pool
         self._trigger = hctx.trigger
         self._new_case_poller: SalesforceNewCasePoller | None
+        self._feed_item_poller: SalesforceCaseFeedItemPoller | None
 
     @logfire.instrument("SalesforceEventHandler start")
     async def start(self, tasks: TaskGroup):
@@ -42,14 +45,21 @@ class SalesforceEventHandler:
             handler=self.handle_updated_case_assignee,
         )
 
-        # for now, we are going to use just assignment events
-        # tasks.create_task(self._subscribe_to_new_cases())
+        self._feed_item_poller = SalesforceCaseFeedItemPoller(
+            pool=self._pool,
+            salesforce_client=self._salesforce_client,
+            handler=self.handle_new_feed_item,
+        )
 
         tasks.create_task(self._subscribe_to_case_assignee_changed())
-        self._new_case_poller.start()
         tasks.create_task(self._run_schedule())
 
-        await self._new_case_poller._process_missed_cases()
+        # poller will look for cases that have been created+assigned
+        # that the agent has "missed"
+        self._new_case_poller.start(run_immediate=True)
+
+        # similarly, look for case feed items that the agent missed
+        self._feed_item_poller.start(run_immediate=True)
 
     def _upsert_case_push_topic_definition(
         self,
@@ -141,22 +151,6 @@ class SalesforceEventHandler:
 
         await self._trigger.put(True)
 
-    async def _subscribe_to_new_cases(self):
-        try:
-            topic_name = "NewCasesTopic"
-            self._upsert_case_push_topic_definition(
-                topic_name=topic_name,
-                fields=CASE_FIELDS,
-                notifyOnCreate=True,
-            )
-            await subscribe_to_topic(
-                salesforce_client=self._salesforce_client,
-                topic_name=topic_name,
-                handler=self.handle_new_case,
-            )
-        except Exception:
-            logfire.exception("Error in subscribe_to_new_cases")
-
     async def _subscribe_to_case_assignee_changed(self):
         try:
             topic_name = "CaseOwnerChangedTopic"
@@ -173,3 +167,19 @@ class SalesforceEventHandler:
             )
         except Exception:
             logfire.exception("Error in subscribe_to_case_assignee_changed")
+
+    @logfire.instrument("handle_new_feed_item", extract_args=False)
+    async def handle_new_feed_item(self, feed_item: SalesforceFeedItem):
+
+        event_ts = None
+        if feed_item.CreatedDate:
+            dt = datetime.fromisoformat(feed_item.CreatedDate)
+            event_ts = str(dt.timestamp())
+
+        await insert_event(
+            pool=self._pool,
+            event=SalesforceFeedItemEvent(
+                feed_item=feed_item, event_ts=event_ts
+            ).model_dump(mode="json"),
+        )
+        await self._trigger.put(True)

--- a/tiger_agent/events/types.py
+++ b/tiger_agent/events/types.py
@@ -12,7 +12,6 @@ from tiger_agent.salesforce.types import (
     SalesforceAssignmentChangedEvent,
     SalesforceCreateNewCaseEvent,
     SalesforceFeedItemEvent,
-    SalesforceNewCaseEvent,
 )
 from tiger_agent.slack.types import BotInfo, SlackAppMentionEvent, SlackMessageEvent
 
@@ -63,7 +62,6 @@ class Event(BaseModel):
         SlackAppMentionEvent
         | SlackMessageEvent
         | SalesforceCreateNewCaseEvent
-        | SalesforceNewCaseEvent
         | SalesforceAssignmentChangedEvent
         | SalesforceFeedItemEvent
     )

--- a/tiger_agent/events/types.py
+++ b/tiger_agent/events/types.py
@@ -11,6 +11,7 @@ from slack_bolt.app.async_app import AsyncApp
 from tiger_agent.salesforce.types import (
     SalesforceAssignmentChangedEvent,
     SalesforceCreateNewCaseEvent,
+    SalesforceFeedItemEvent,
     SalesforceNewCaseEvent,
 )
 from tiger_agent.slack.types import BotInfo, SlackAppMentionEvent, SlackMessageEvent
@@ -64,6 +65,7 @@ class Event(BaseModel):
         | SalesforceCreateNewCaseEvent
         | SalesforceNewCaseEvent
         | SalesforceAssignmentChangedEvent
+        | SalesforceFeedItemEvent
     )
 
 

--- a/tiger_agent/prompts/system_prompt.md
+++ b/tiger_agent/prompts/system_prompt.md
@@ -38,7 +38,7 @@ If asked to do something that falls outside your purpose or abilities as defined
 
 ## Salesforce Support Case Triage
 
-- Use the `salesforce-new-case-notification` skill to handle new case events (`subtype: new_case`)
+- Use the `salesforce-new-case-notification` skill to handle case events(`subtype: new_assignee`)
 - Do not ask clarifying questions — act immediately on the data provided
 - Return the structured notification as your response; do not add conversational framing around it
 

--- a/tiger_agent/salesforce/case_feed_item_poller.py
+++ b/tiger_agent/salesforce/case_feed_item_poller.py
@@ -1,0 +1,91 @@
+"""
+Poll Salesforce for new Chatter feed items on cases.
+
+Neither FeedItem nor CaseComment support PushTopics or CDC, so we poll
+the Chatter news feed on an interval and call the handler for any new
+items found since the last poll.
+"""
+
+import asyncio
+import logging
+from collections.abc import Callable, Coroutine
+from datetime import datetime, timedelta
+from typing import Any
+
+import logfire
+import schedule
+from psycopg_pool import AsyncConnectionPool
+from pytz import UTC
+from simple_salesforce.api import Salesforce
+
+from tiger_agent.db.utils import filter_new_feed_items
+from tiger_agent.salesforce.types import SalesforceFeedItem
+from tiger_agent.salesforce.utils import get_recent_case_feed_items
+
+logger = logging.getLogger(__name__)
+
+# on startup, how far back we should grab feeditems from
+INITIAL_LOOKBACK_IN_HOURS = 12
+
+
+class SalesforceCaseFeedItemPoller:
+    def __init__(
+        self,
+        pool: AsyncConnectionPool,
+        salesforce_client: Salesforce,
+        handler: Callable[[SalesforceFeedItem], Coroutine[Any, Any, None]],
+        poll_interval_seconds: int = 20,
+    ):
+        self._salesforce_client = salesforce_client
+        self._pool = pool
+        self._handler = handler
+        self._poll_interval_seconds = poll_interval_seconds
+        self._last_poll: datetime | None = None
+
+    @logfire.instrument("SalesforceFeedItemPoller._poll")
+    async def _poll(self) -> None:
+        # TODO: can improve the fallback by doing a query on the last feed item event in the db
+        since = self._last_poll or (
+            datetime.now(UTC) - timedelta(hours=INITIAL_LOOKBACK_IN_HOURS)
+        )
+        self._last_poll = datetime.now(UTC)
+        since_str = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        case_feed_items = get_recent_case_feed_items(
+            salesforce_client=self._salesforce_client,
+            types=["TextPost", "ContentPost"],
+            public_only=True,
+            created_after=since_str,
+        )
+
+        # filter out feed items that have already been handled
+        filtered_new_feed_items = await filter_new_feed_items(
+            self._pool, feed_items=case_feed_items
+        )
+
+        if not filtered_new_feed_items:
+            return
+
+        logfire.info("New case feed items found", count=len(filtered_new_feed_items))
+        for feed_item in filtered_new_feed_items:
+            try:
+                await self._handler(feed_item)
+            except Exception:
+                logfire.exception(
+                    "Error handling new feed item", feed_item_id=feed_item.Id
+                )
+
+    def start(self, run_immediate: bool = False) -> None:
+        def job():
+            asyncio.create_task(self._poll())
+
+        schedule.every(self._poll_interval_seconds).seconds.do(job)
+        logger.info(
+            "Scheduled case feed poll every %d second(s)",
+            self._poll_interval_seconds,
+        )
+
+        if not run_immediate:
+            return
+
+        job()

--- a/tiger_agent/salesforce/case_feed_item_poller.py
+++ b/tiger_agent/salesforce/case_feed_item_poller.py
@@ -42,7 +42,6 @@ class SalesforceCaseFeedItemPoller:
         self._poll_interval_seconds = poll_interval_seconds
         self._last_poll: datetime | None = None
 
-    @logfire.instrument("SalesforceFeedItemPoller._poll")
     async def _poll(self) -> None:
         # TODO: can improve the fallback by doing a query on the last feed item event in the db
         since = self._last_poll or (

--- a/tiger_agent/salesforce/new_case_poller.py
+++ b/tiger_agent/salesforce/new_case_poller.py
@@ -79,10 +79,15 @@ class SalesforceNewCasePoller:
             )
             await self._handler(case)
 
-    def start(self) -> None:
+    def start(self, run_immediate: bool = False) -> None:
         def job():
             asyncio.create_task(self._process_missed_cases())
 
         schedule.every(5).minutes.do(job)
 
         logger.info("Scheduled poll_missed_new_cases every 5 minutes")
+
+        if not run_immediate:
+            return
+
+        job()

--- a/tiger_agent/salesforce/types.py
+++ b/tiger_agent/salesforce/types.py
@@ -10,6 +10,13 @@ from tiger_agent.salesforce.constants import (
 )
 
 
+@dataclass
+class EmailAttachment:
+    name: str
+    body: bytes
+    content_type: str
+
+
 class SalesforceUser(BaseModel):
     Id: str | None = None
     Username: str | None = None
@@ -59,6 +66,7 @@ class SalesforceBaseEvent(BaseModel):
 
     type: str = "salesforce_event"
     subtype: str
+    event_ts: str | None = None
 
 
 class SalesforceNewCaseEvent(SalesforceBaseEvent):
@@ -93,6 +101,30 @@ class SalesforceAssignmentChangedEvent(SalesforceBaseEvent):
     subtype: str = "new_assignee"
     case: CaseData
     update_link_to_thread: bool = True
+
+
+class SalesforceFeedItem(BaseModel):
+    """Pydantic model for a Salesforce FeedItem SOQL record."""
+
+    model_config = {"extra": "allow"}
+
+    Id: str
+    ParentId: str | None = None
+    Body: str | None = None
+    Type: str | None = None
+    CreatedDate: str | None = None
+    CreatedById: str | None = None
+
+
+# at present, we are using these to synchronize
+# comments made on cases with a Slack thread
+# that is linked to the case
+class SalesforceFeedItemEvent(SalesforceBaseEvent):
+    """Pydantic model for a new Salesforce FeedItem (Chatter post) on a case."""
+
+    type: str = "salesforce_event"
+    subtype: str = "new_feed_item"
+    feed_item: SalesforceFeedItem
 
 
 class AgentFeedbackRatingEvent(BaseModel):

--- a/tiger_agent/salesforce/types.py
+++ b/tiger_agent/salesforce/types.py
@@ -95,6 +95,11 @@ class SalesforceAssignmentChangedEvent(SalesforceBaseEvent):
     update_link_to_thread: bool = True
 
 
+class SalesforceFeedItemCreatedBy(BaseModel):
+    Name: str | None = None
+    Email: str | None = None
+
+
 class SalesforceFeedItem(BaseModel):
     """Pydantic model for a Salesforce FeedItem SOQL record."""
 
@@ -106,6 +111,7 @@ class SalesforceFeedItem(BaseModel):
     Type: str | None = None
     CreatedDate: str | None = None
     CreatedById: str | None = None
+    CreatedBy: SalesforceFeedItemCreatedBy | None = None
 
 
 # at present, we are using these to synchronize

--- a/tiger_agent/salesforce/types.py
+++ b/tiger_agent/salesforce/types.py
@@ -69,14 +69,6 @@ class SalesforceBaseEvent(BaseModel):
     event_ts: str | None = None
 
 
-class SalesforceNewCaseEvent(SalesforceBaseEvent):
-    """Pydantic model for Salesforce new case event."""
-
-    type: str = "salesforce_event"
-    subtype: str = "new_case"
-    case: CaseData
-
-
 # this event represents the initiation of a new Salesforce
 # case via Slack. We want to capture the case details, as well as
 # created the case and from which channel they created it

--- a/tiger_agent/salesforce/utils.py
+++ b/tiger_agent/salesforce/utils.py
@@ -3,9 +3,11 @@ import base64
 import os
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from typing import Any
 
 import logfire
+import pytz
 from aiosfstream_ng.client import Client
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool
@@ -20,7 +22,12 @@ from tiger_agent.salesforce.constants import (
     CASE_FIELDS,
     SALESFORCE_DOMAIN,
 )
-from tiger_agent.salesforce.types import CaseData, SalesforceBaseEvent, ServiceRecord
+from tiger_agent.salesforce.types import (
+    CaseData,
+    ChatterFeedItem,
+    SalesforceBaseEvent,
+    ServiceRecord,
+)
 
 RECONNECT_DELAY_SECONDS = 30
 IGNORED_CONTACT_EMAILS = set(
@@ -82,6 +89,63 @@ async def subscribe_to_topic(
         except Exception:
             logfire.exception(
                 "Streaming connection error, reconnecting",
+                extra={"topic_name": topic_name, "delay": RECONNECT_DELAY_SECONDS},
+            )
+
+        await asyncio.sleep(RECONNECT_DELAY_SECONDS)
+
+
+async def subscribe_to_case_comment_topic(
+    topic_name: str,
+    handler: Callable[[str, str], Coroutine[Any, Any, None]],
+):
+    """Subscribe to a PushTopic for new CaseComment events.
+
+    CaseComment is the underlying SObject created when someone posts a
+    Chatter comment on a case. FeedItem and CDC are not supported for
+    Chatter posts, so this is the recommended streaming approach.
+
+    Calls handler(case_id, comment_id) for each new comment.
+    """
+    channel = f"/topic/{topic_name}"
+    while True:
+        try:
+            async with Client(ClientCredentialsAuthenticator()) as streaming_client:
+                await streaming_client.subscribe(channel)
+                logfire.info(
+                    "Subscribed to CaseComment PushTopic",
+                    extra={"topic_name": topic_name},
+                )
+
+                async for message in streaming_client:
+                    data = message.get("data", {})
+                    sobject = data.get("sobject", {})
+
+                    comment_id = sobject.get("Id")
+                    case_id = sobject.get("ParentId")
+                    if not comment_id or not case_id:
+                        continue
+
+                    try:
+                        logfire.info(
+                            "Handling CaseComment event",
+                            extra={"topic": topic_name, "payload": data},
+                        )
+                        await handler(case_id, comment_id)
+                    except Exception:
+                        logfire.exception(
+                            "Error handling new case comment",
+                            comment_id=comment_id,
+                            case_id=case_id,
+                        )
+
+            logfire.warning(
+                "CaseComment streaming client exited unexpectedly, reconnecting",
+                extra={"topic_name": topic_name, "delay": RECONNECT_DELAY_SECONDS},
+            )
+        except Exception:
+            logfire.exception(
+                "CaseComment streaming connection error, reconnecting",
                 extra={"topic_name": topic_name, "delay": RECONNECT_DELAY_SECONDS},
             )
 
@@ -278,6 +342,79 @@ def add_case_email_comment(
                 "Could not attach file to Salesforce email message",
                 extra={"email_message_id": email_message_id, "name": attachment.name},
             )
+
+
+def get_case_chatter_feed(
+    salesforce_client: Salesforce,
+    case_id: str,
+    created_after: str | None = None,
+) -> list[ChatterFeedItem]:
+    """Fetch Chatter feed items for a case via the Chatter REST API.
+
+    Uses the Chatter REST API rather than SOQL since FeedItem visibility
+    rules can prevent SOQL from returning internal posts.
+
+    created_after: ISO 8601 datetime string (e.g. "2024-01-01T00:00:00Z") to
+        filter items created after that time.
+    """
+    try:
+        params: dict = {"pageSize": 100, "sort": "CreatedDateAsc"}
+        if created_after is not None:
+            params["updatedSince"] = created_after
+        result = salesforce_client.restful(
+            f"chatter/feeds/record/{case_id}/feed-elements",
+            params=params,
+        )
+        return [ChatterFeedItem(**element) for element in result.get("elements", [])]
+    except Exception:
+        logfire.exception("Failed to fetch case chatter feed", case_id=case_id)
+        return []
+
+
+def get_all_case_chatter_feed(
+    salesforce_client: Salesforce,
+    updated_since: str | None = None,
+) -> list[ChatterFeedItem]:
+    """Fetch Chatter feed items across all cases via the news feed.
+
+    Uses the authenticated user's news feed which surfaces all case chatter
+    visible to that user. Supports updatedSince for incremental polling.
+
+    updated_since: ISO 8601 datetime string (e.g. "2024-01-01T00:00:00Z").
+    """
+    try:
+        params: dict = {"pageSize": 100}
+        if updated_since is not None:
+            params["updatedSince"] = updated_since
+        result = salesforce_client.restful(
+            "chatter/feeds/news/me/feed-elements",
+            params=params,
+        )
+        return [ChatterFeedItem(**element) for element in result.get("elements", [])]
+    except Exception:
+        logfire.exception("Failed to fetch all case chatter feed")
+        return []
+
+
+def get_recent_feed_items(
+    salesforce_client: Salesforce,
+    created_after: str | None = None,
+) -> list[ChatterFeedItem]:
+    """Fetch recent FeedItems using the SObject REST API, limited to 100."""
+    try:
+        params = {"limit": 100, "order": "CreatedDate ASC"}
+        if created_after is not None:
+            params["where"] = f"CreatedDate > {created_after}"
+        end = datetime.now(pytz.UTC)
+        ids = salesforce_client.FeedItem.updated(end - timedelta(days=2), end)
+        feed_items = [
+            salesforce_client.FeedItem.get(record_id)
+            for record_id in ids.get("ids", [])
+        ]
+        return feed_items
+    except Exception:
+        logfire.exception("Failed to fetch recent feed items")
+        return []
 
 
 def get_project_ids_for_account(

--- a/tiger_agent/salesforce/utils.py
+++ b/tiger_agent/salesforce/utils.py
@@ -2,19 +2,12 @@ import asyncio
 import base64
 import os
 from collections.abc import Callable, Coroutine
-from dataclasses import dataclass
-from datetime import datetime, timedelta
 from typing import Any
 
 import logfire
-import pytz
 from aiosfstream_ng.client import Client
-from psycopg.rows import dict_row
-from psycopg_pool import AsyncConnectionPool
-from pydantic import ValidationError
 from simple_salesforce.api import Salesforce
 
-from tiger_agent.events.types import Event
 from tiger_agent.salesforce.clients import (
     ClientCredentialsAuthenticator,
 )
@@ -24,8 +17,8 @@ from tiger_agent.salesforce.constants import (
 )
 from tiger_agent.salesforce.types import (
     CaseData,
-    ChatterFeedItem,
-    SalesforceBaseEvent,
+    EmailAttachment,
+    SalesforceFeedItem,
     ServiceRecord,
 )
 
@@ -158,87 +151,6 @@ def should_ignore_new_case(case: CaseData) -> bool:
     return case.ContactEmail in IGNORED_CONTACT_EMAILS
 
 
-@logfire.instrument("is_case_assignment_new", extract_args=False)
-async def is_case_assignment_new(
-    pool: AsyncConnectionPool, case_id: str, owner_id: str
-) -> bool:
-    """
-    Verifies if the Salesforce case assignment is new e.g. if the assigned user (owner) has actually changed.
-    This is done by reading the event and event_hist table for the most recent event for that case
-
-
-    Args:
-        case_id: The ID of the Salesforce case
-        owner_id: The ID of the assignee
-
-    Returns:
-        True if the given owner id is different from the most recently processed/unprocessed
-        Salesforce event
-    """
-    async with (
-        pool.connection() as con,
-        con.cursor(row_factory=dict_row) as cur,
-    ):
-        result = await cur.execute(
-            """select * from agent.event
-                WHERE
-                    event->>'type' = 'salesforce_event'
-                    AND event->>'subtype' = 'new_assignee'
-                    AND event->'case'->>'Id' = %s
-                    order by event_ts desc limit 1;""",
-            (case_id,),
-        )
-        current_row: dict[str, Any] | None = await result.fetchone()
-
-        if current_row:
-            try:
-                event = Event(**current_row)
-
-                # there is an unprocessed new_assignee event
-                # that has the same owner
-                if (
-                    isinstance(event.event, SalesforceBaseEvent)
-                    and event.event.case.OwnerId == owner_id
-                ):
-                    return False
-            except ValidationError as e:
-                logfire.error(
-                    "failed to parse historical event",
-                    exc_info=e,
-                    extra={"row": current_row},
-                )
-
-        result = await cur.execute(
-            """select * from agent.event_hist 
-                WHERE
-                    event->>'type' = 'salesforce_event'
-                    AND event->>'subtype' = 'new_assignee'
-                    AND event->'case'->>'Id' = %s
-                    order by event_ts desc limit 1;""",
-            (case_id,),
-        )
-        processed_row: dict[str, Any] | None = await result.fetchone()
-        if processed_row:
-            try:
-                event = Event(**processed_row)
-
-                # there is an processed new_assignee event
-                # that has the same owner
-                if (
-                    isinstance(event.event, SalesforceBaseEvent)
-                    and event.event.case.OwnerId == owner_id
-                ):
-                    return False
-            except ValidationError as e:
-                logfire.error(
-                    "failed to parse historical event",
-                    exc_info=e,
-                    extra={"row": processed_row},
-                )
-
-        return True
-
-
 def create_case_url(case: CaseData) -> str:
     return f"https://{SALESFORCE_DOMAIN}/lightning/r/Case/{case.Id}/view"
 
@@ -289,13 +201,6 @@ def get_services_for_account(
     ]
 
 
-@dataclass
-class EmailAttachment:
-    name: str
-    body: bytes
-    content_type: str
-
-
 def add_case_email_comment(
     salesforce_client: Salesforce,
     case_id: str,
@@ -344,74 +249,28 @@ def add_case_email_comment(
             )
 
 
-def get_case_chatter_feed(
-    salesforce_client: Salesforce,
-    case_id: str,
-    created_after: str | None = None,
-) -> list[ChatterFeedItem]:
-    """Fetch Chatter feed items for a case via the Chatter REST API.
-
-    Uses the Chatter REST API rather than SOQL since FeedItem visibility
-    rules can prevent SOQL from returning internal posts.
-
-    created_after: ISO 8601 datetime string (e.g. "2024-01-01T00:00:00Z") to
-        filter items created after that time.
-    """
-    try:
-        params: dict = {"pageSize": 100, "sort": "CreatedDateAsc"}
-        if created_after is not None:
-            params["updatedSince"] = created_after
-        result = salesforce_client.restful(
-            f"chatter/feeds/record/{case_id}/feed-elements",
-            params=params,
-        )
-        return [ChatterFeedItem(**element) for element in result.get("elements", [])]
-    except Exception:
-        logfire.exception("Failed to fetch case chatter feed", case_id=case_id)
-        return []
-
-
-def get_all_case_chatter_feed(
-    salesforce_client: Salesforce,
-    updated_since: str | None = None,
-) -> list[ChatterFeedItem]:
-    """Fetch Chatter feed items across all cases via the news feed.
-
-    Uses the authenticated user's news feed which surfaces all case chatter
-    visible to that user. Supports updatedSince for incremental polling.
-
-    updated_since: ISO 8601 datetime string (e.g. "2024-01-01T00:00:00Z").
-    """
-    try:
-        params: dict = {"pageSize": 100}
-        if updated_since is not None:
-            params["updatedSince"] = updated_since
-        result = salesforce_client.restful(
-            "chatter/feeds/news/me/feed-elements",
-            params=params,
-        )
-        return [ChatterFeedItem(**element) for element in result.get("elements", [])]
-    except Exception:
-        logfire.exception("Failed to fetch all case chatter feed")
-        return []
-
-
-def get_recent_feed_items(
+def get_recent_case_feed_items(
     salesforce_client: Salesforce,
     created_after: str | None = None,
-) -> list[ChatterFeedItem]:
-    """Fetch recent FeedItems using the SObject REST API, limited to 100."""
+    types: list[str] | None = None,
+    public_only: bool = False,
+) -> list[SalesforceFeedItem]:
     try:
-        params = {"limit": 100, "order": "CreatedDate ASC"}
+        conditions = ["Parent.Type = 'Case'"]
         if created_after is not None:
-            params["where"] = f"CreatedDate > {created_after}"
-        end = datetime.now(pytz.UTC)
-        ids = salesforce_client.FeedItem.updated(end - timedelta(days=2), end)
-        feed_items = [
-            salesforce_client.FeedItem.get(record_id)
-            for record_id in ids.get("ids", [])
-        ]
-        return feed_items
+            conditions.append(f"CreatedDate > {created_after}")
+        if types:
+            type_list = ", ".join(f"'{t}'" for t in types)
+            conditions.append(f"Type IN ({type_list})")
+        if public_only:
+            conditions.append("Visibility = 'AllUsers'")
+        where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+        result = salesforce_client.query(
+            f"SELECT Id, ParentId, Body, Type, CreatedDate, CreatedById, Visibility"
+            f" FROM FeedItem{where}"
+            f" ORDER BY CreatedDate DESC"
+        )
+        return [SalesforceFeedItem(**r) for r in result.get("records", [])]
     except Exception:
         logfire.exception("Failed to fetch recent feed items")
         return []

--- a/tiger_agent/salesforce/utils.py
+++ b/tiger_agent/salesforce/utils.py
@@ -266,7 +266,8 @@ def get_recent_case_feed_items(
             conditions.append("Visibility = 'AllUsers'")
         where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
         result = salesforce_client.query(
-            f"SELECT Id, ParentId, Body, Type, CreatedDate, CreatedById, Visibility"
+            f"SELECT Id, ParentId, Body, Type, CreatedDate, CreatedById,"
+            f" CreatedBy.Name, CreatedBy.Email, Visibility"
             f" FROM FeedItem{where}"
             f" ORDER BY CreatedDate DESC"
         )

--- a/tiger_agent/slack/utils.py
+++ b/tiger_agent/slack/utils.py
@@ -234,7 +234,11 @@ async def fetch_thread_messages(
 
 @logfire.instrument("post_response", extract_args=["channel", "thread_ts"])
 async def post_response(
-    client: AsyncWebClient, channel: str, thread_ts: str | None, text: str
+    client: AsyncWebClient,
+    channel: str,
+    thread_ts: str | None,
+    text: str,
+    use_mrkdwn: bool = False,
 ) -> AsyncSlackResponse:
     """Post a response message to Slack with rich formatting.
 
@@ -255,7 +259,9 @@ async def post_response(
         channel=channel,
         thread_ts=thread_ts,
         text=text,
-        blocks=[{"type": "markdown", "text": text}],
+        blocks=[{"type": "markdown", "text": text}]
+        if not use_mrkdwn
+        else [{"type": "section", "fields": [{"type": "mrkdwn", "text": text}]}],
         unfurl_links=False,
         unfurl_media=False,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -892,6 +892,16 @@ wheels = [
 ]
 
 [[package]]
+name = "html-to-markdown"
+version = "3.2.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/05/da5a1518899937ae559e4e4126ac872e5c65f6c7f05d094c4b1a9609e161/html_to_markdown-3.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c3c2365f074d08d08a4f368d0ca5a5887bccae5b6104ac37c66c24d61f3e571", size = 5460630, upload-time = "2026-04-20T09:09:20.336Z" },
+    { url = "https://files.pythonhosted.org/packages/be/bc/92632edc96b188ef8c7e96785c4893276976a6251dc6939512f1b607676b/html_to_markdown-3.2.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f8fcc36e1bbec4da7dc25fe690c23de45f813c1867ca37f34f3276551324e1e8", size = 5961770, upload-time = "2026-04-20T09:09:22.566Z" },
+    { url = "https://files.pythonhosted.org/packages/76/ea/cfe8f60fbfdbdd0ed524caf300cc70e16a66e309ae4cd7cef477e5d8dac1/html_to_markdown-3.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:4b32d8287abc1eefb1aa27d6eebbb8a50b4b2bc33411dec1ef71075bb898e5c2", size = 5768211, upload-time = "2026-04-20T09:09:24.574Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -2706,6 +2716,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiosfstream-ng" },
     { name = "click" },
+    { name = "html-to-markdown" },
     { name = "jinja2" },
     { name = "logfire", extra = ["httpx", "psycopg", "system-metrics"] },
     { name = "psycopg", extra = ["binary", "pool"] },
@@ -2728,6 +2739,7 @@ dev = [
 requires-dist = [
     { name = "aiosfstream-ng", specifier = ">=0.5.1" },
     { name = "click", specifier = ">=8.3.0" },
+    { name = "html-to-markdown", specifier = ">=3.2.6" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "logfire", extras = ["httpx", "psycopg", "system-metrics"], specifier = ">=4.10.0" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.10" },

--- a/uv.lock
+++ b/uv.lock
@@ -892,13 +892,12 @@ wheels = [
 ]
 
 [[package]]
-name = "html-to-markdown"
-version = "3.2.6"
+name = "html-slacker"
+version = "0.1.6"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/3b/e6fb83106593410b047deedcf13d3f7f34048d467ed58d34158ec1ffc273/html-slacker-0.1.6.tar.gz", hash = "sha256:22dd8847d01e8516e75d8f6af8572356568cd439134b846b00e62dd1e4df4ee1", size = 2490, upload-time = "2019-03-05T17:03:52.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/05/da5a1518899937ae559e4e4126ac872e5c65f6c7f05d094c4b1a9609e161/html_to_markdown-3.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c3c2365f074d08d08a4f368d0ca5a5887bccae5b6104ac37c66c24d61f3e571", size = 5460630, upload-time = "2026-04-20T09:09:20.336Z" },
-    { url = "https://files.pythonhosted.org/packages/be/bc/92632edc96b188ef8c7e96785c4893276976a6251dc6939512f1b607676b/html_to_markdown-3.2.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f8fcc36e1bbec4da7dc25fe690c23de45f813c1867ca37f34f3276551324e1e8", size = 5961770, upload-time = "2026-04-20T09:09:22.566Z" },
-    { url = "https://files.pythonhosted.org/packages/76/ea/cfe8f60fbfdbdd0ed524caf300cc70e16a66e309ae4cd7cef477e5d8dac1/html_to_markdown-3.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:4b32d8287abc1eefb1aa27d6eebbb8a50b4b2bc33411dec1ef71075bb898e5c2", size = 5768211, upload-time = "2026-04-20T09:09:24.574Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/4f/2286db7784550360b0a1d0c0e929ef578d327d53f23dbb89a691b291c564/html_slacker-0.1.6-py3-none-any.whl", hash = "sha256:4458b7c18eb45fda04433364fa065f0107599516fc3cb4ee59de01256821ce7f", size = 3694, upload-time = "2019-03-05T17:03:50.453Z" },
 ]
 
 [[package]]
@@ -2716,7 +2715,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiosfstream-ng" },
     { name = "click" },
-    { name = "html-to-markdown" },
+    { name = "html-slacker" },
     { name = "jinja2" },
     { name = "logfire", extra = ["httpx", "psycopg", "system-metrics"] },
     { name = "psycopg", extra = ["binary", "pool"] },
@@ -2739,7 +2738,7 @@ dev = [
 requires-dist = [
     { name = "aiosfstream-ng", specifier = ">=0.5.1" },
     { name = "click", specifier = ">=8.3.0" },
-    { name = "html-to-markdown", specifier = ">=3.2.6" },
+    { name = "html-slacker" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "logfire", extras = ["httpx", "psycopg", "system-metrics"], specifier = ">=4.10.0" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.10" },


### PR DESCRIPTION
## What
This syncs all public posts made on a Salesforce case with the correlated Slack thread.

## How
Unfortunately, there is no way to subscribe to create an push topic for `FeedItem` objects from Slack, as we are doing for listening for new cases. So, this PR adds a new `SalesforceCaseFeedItemPoller` that will do the following every 20 seconds:
* grab all public case FeedItems from that last 12 hours (I may optimize this later)
* filter out any handled FeedItems (by using `event_ts`,`FeedItem.Id`, `event->type` and `event->subtype`.
* insert a new `SalesforceFeedItemEvent`

When a worker gets this new event, it will post the contents of the message (convert HTML -> markdown) and post it to the correct channel+thread, citing author:
<img width="395" height="150" alt="image" src="https://github.com/user-attachments/assets/29b8676d-bffc-4cb4-adc4-751a6182b7d0" />

Will block quote the contents and will attempt to preserve any text adornments (e.g bold, italic ... but underline not supported?!)

## Other Changes
This removes types/logic related to handling new case events. Initially, this was the event that was used to trigger an agentic response to new cases, however, we changed the flow to trigger off of when the assignee has changed.