### PR TITLE
[CHORE] update is_external and add scope

### DIFF
--- a/slack-manifest.json
+++ b/slack-manifest.json
@@ -38,7 +38,8 @@
         "mpim:read",
         "pins:write",
         "im:read",
-        "files:read"
+        "files:read",
+        "team:read"
       ]
     }
   },
@@ -51,6 +52,7 @@
         "function_executed"
       ]
     },
+    "user_events": ["message.channels"],
     "interactivity": {
       "is_enabled": true
     },

--- a/tiger_agent/events/slack.py
+++ b/tiger_agent/events/slack.py
@@ -186,7 +186,10 @@ class SlackEventHandler:
                     user_info = await fetch_user_info(
                         self._hctx.app.client, user_id=user
                     )
-                    user_is_external = user_info.is_external
+                    user_is_external = (
+                        user_info.is_external
+                        or user_info.team_id != self._bot_info.team_id
+                    )
                     text_prefix, html_prefix = await self.get_reply_prefix_for_sender(
                         user_info
                     )

--- a/tiger_agent/slack/types.py
+++ b/tiger_agent/slack/types.py
@@ -131,11 +131,14 @@ class UserInfo(BaseModel):
     profile: UserProfile
     is_restricted: bool = False
     is_ultra_restricted: bool = False
+    is_stranger: bool = False
     is_external: bool = False
 
     @model_validator(mode="after")
     def set_is_external(self) -> "UserInfo":
-        self.is_external = self.is_restricted or self.is_ultra_restricted
+        self.is_external = (
+            self.is_restricted or self.is_ultra_restricted or self.is_stranger
+        )
         return self
 
 


### PR DESCRIPTION
This is a follow up to https://github.com/timescale/tiger-agents-for-work/pull/170

Apparently, slack uses `is_stranger: true` for some cases of external users (see [doc](https://docs.slack.dev/reference/objects/user-object/))

Adding logic for that and fallback to just see if the user is not in the bot's workspace.

Also, adding a scope to read team info