### PR TITLE
[CHORE] Fix fetching threads with bots in them

### DIFF
--- a/tiger_agent/prompts/utils.py
+++ b/tiger_agent/prompts/utils.py
@@ -21,9 +21,14 @@ def format_thread_history(
     lines: list[str] = []
 
     for msg in thread_messages:
+        sender_id = msg.user or msg.bot_id
         if filter_message_ts and msg.ts in filter_message_ts:
             continue
-        actor = f"<@{bot_info.user_id}> (you)" if msg.user == bot_info.user_id else f"<@{msg.user}>"
+        actor = (
+            f"<@{bot_info.user_id}> (you)"
+            if sender_id == bot_info.user_id
+            else f"<@{sender_id}>"
+        )
         ts = datetime.fromtimestamp(float(msg.ts), tz=UTC).isoformat()
         lines.append(f"[{ts}] {actor}: {msg.text}")
 

--- a/tiger_agent/slack/types.py
+++ b/tiger_agent/slack/types.py
@@ -221,9 +221,10 @@ class SlackBaseEvent(BaseModel):
     ts: str
     thread_ts: str | None = None
     team: str | None = None
+    bot_id: str | None = None
     text: str
     type: str
-    user: str
+    user: str | None = None
     blocks: list[dict[str, Any]] | None = None
     channel: str
     event_ts: str


### PR DESCRIPTION
## What
On Slack message models, makes `user` nullable and adds `bot_id`. When a message comes from a bot, it lacks `user` field. So when constructing the message history, fallback on `bot_id` if `user` is not present

## Why
Eon failed to fetch conversation here https://iobeam.slack.com/archives/C092P1U3S4V/p1776884772588089