### PR TITLE
[AGE-472] Include attachments from Salesforce case

### DIFF
--- a/tiger_agent/agent/tiger_agent.py
+++ b/tiger_agent/agent/tiger_agent.py
@@ -61,7 +61,12 @@ from tiger_agent.salesforce.types import (
     SalesforceCreateNewCaseEvent,
     SalesforceFeedItemEvent,
 )
-from tiger_agent.salesforce.utils import create_case, create_case_url
+from tiger_agent.salesforce.utils import (
+    create_case,
+    create_case_url,
+    download_feed_attachment,
+    get_feed_attachment_ids,
+)
 from tiger_agent.slack.types import (
     BotInfo,
     SlackAppMentionEvent,
@@ -323,12 +328,18 @@ class TigerAgent:
         body = "\n".join(f"> {line}" for line in markdown_conversion.splitlines())
         text = f"_From_ *{event.feed_item.CreatedBy.Name}* _via Tigerdata Support_\n\n{body}"
 
+        attachment_ids = get_feed_attachment_ids(hctx.salesforce_client, event.feed_item.Id)
+        image_attachments = [
+            download_feed_attachment(hctx.salesforce_client, aid) for aid in attachment_ids
+        ]
+
         await post_response(
             client=hctx.app.client,
             channel=channel_id,
             thread_ts=thread_ts,
             text=text,
             use_mrkdwn=True,
+            image_attachments=image_attachments,
         )
 
     async def handle_create_salesforce_case(

--- a/tiger_agent/salesforce/types.py
+++ b/tiger_agent/salesforce/types.py
@@ -4,10 +4,15 @@ from pydantic import BaseModel
 
 
 @dataclass
-class EmailAttachment:
+class FileAttachment:
     name: str
     body: bytes
     content_type: str
+
+
+@dataclass
+class EmailAttachment(FileAttachment):
+    pass
 
 
 class SalesforceUser(BaseModel):

--- a/tiger_agent/salesforce/utils.py
+++ b/tiger_agent/salesforce/utils.py
@@ -18,6 +18,7 @@ from tiger_agent.salesforce.constants import (
 from tiger_agent.salesforce.types import (
     CaseData,
     EmailAttachment,
+    FileAttachment,
     SalesforceFeedItem,
     ServiceRecord,
 )
@@ -275,6 +276,73 @@ def get_recent_case_feed_items(
     except Exception:
         logfire.exception("Failed to fetch recent feed items")
         return []
+
+
+def get_feed_attachment_ids(
+    salesforce_client: Salesforce,
+    feed_item_id: str,
+) -> list[str]:
+    """Return the Ids of all FeedAttachments for a given FeedItem."""
+    result = salesforce_client.query(
+        f"SELECT Id FROM FeedAttachment WHERE FeedEntityId = '{feed_item_id}'"
+    )
+    return [r["Id"] for r in result.get("records", [])]
+
+
+def download_feed_attachment(
+    salesforce_client: Salesforce,
+    feed_attachment_id: str,
+) -> FileAttachment:
+    """Download the body of a Salesforce FeedAttachment by its Id.
+
+    FeedAttachment records link a ContentDocument to a FeedItem. The binary
+    content is fetched from the ContentVersion REST endpoint.
+    """
+    attachment = salesforce_client.FeedAttachment.get(feed_attachment_id)
+    record_id = attachment.get("RecordId")
+    if not record_id:
+        raise ValueError(f"FeedAttachment {feed_attachment_id} has no RecordId")
+    attachment_type = attachment.get("Type", "")
+
+    version = salesforce_client.query(
+        f"SELECT Id, Title, FileExtension, VersionData"
+        f" FROM ContentVersion"
+        f" WHERE ContentDocumentId = '{record_id}'"
+        f" AND IsLatest = true"
+        f" LIMIT 1"
+    )
+    records = version.get("records", [])
+    if not records:
+        raise ValueError(f"No ContentVersion found for ContentDocument {record_id}")
+
+    cv = records[0]
+    url = f"https://{salesforce_client.sf_instance}{cv['VersionData']}"
+    response = salesforce_client.session.get(
+        url,
+        headers={
+            "Authorization": f"Bearer {salesforce_client.session_id}",
+            "Accept": "*/*",
+        },
+    )
+    response.raise_for_status()
+
+    name = cv.get("Title") or feed_attachment_id
+    extension = cv.get("FileExtension")
+    if extension:
+        name = f"{name}.{extension}"
+
+    _ATTACHMENT_TYPE_TO_MIME = {
+        "InlineImage": "image/png",
+        "File": "application/octet-stream",
+        "Link": "text/uri-list",
+    }
+    content_type = _ATTACHMENT_TYPE_TO_MIME.get(attachment_type, "application/octet-stream")
+
+    return FileAttachment(
+        name=name,
+        body=response.content,
+        content_type=content_type,
+    )
 
 
 def get_project_ids_for_account(

--- a/tiger_agent/slack/utils.py
+++ b/tiger_agent/slack/utils.py
@@ -39,7 +39,7 @@ from slack_sdk.web.async_client import (
     AsyncWebClient,
 )
 
-from tiger_agent.salesforce.types import ServiceRecord
+from tiger_agent.salesforce.types import FileAttachment, ServiceRecord
 from tiger_agent.slack.constants import (
     AGENT_FEEDBACK_RATING,
     CONFIRM_PROACTIVE_PROMPT,
@@ -240,6 +240,7 @@ async def post_response(
     thread_ts: str | None,
     text: str,
     use_mrkdwn: bool = False,
+    image_attachments: list[FileAttachment] | None = None,
 ) -> AsyncSlackResponse:
     """Post a response message to Slack with rich formatting.
 
@@ -252,11 +253,12 @@ async def post_response(
         channel: Slack channel ID to post in
         thread_ts: Thread timestamp to reply to (or message ts to start thread)
         text: Message content with markdown formatting support
+        image_attachments: Optional image files to upload and attach as image blocks
 
     Raises:
         SlackApiError: If message posting fails (not caught, allows caller to handle)
     """
-    return await client.chat_postMessage(
+    response = await client.chat_postMessage(
         channel=channel,
         thread_ts=thread_ts,
         text=text,
@@ -266,6 +268,18 @@ async def post_response(
         unfurl_links=False,
         unfurl_media=False,
     )
+
+    for attachment in image_attachments or []:
+        if not attachment.content_type.startswith("image/"):
+            continue
+        await client.files_upload_v2(
+            channel=channel,
+            thread_ts=thread_ts,
+            filename=attachment.name,
+            content=attachment.body,
+        )
+
+    return response
 
 
 @logfire.instrument("fetch_team_info", extract_args=["team_id"])


### PR DESCRIPTION
## What
This will include image attachments from Salesforce case posts when creating the Slack message.

## Example 

<img width="562" height="715" alt="image" src="https://github.com/user-attachments/assets/62809161-b87a-4e76-9be9-5935b13d6620" />
<img width="429" height="233" alt="image" src="https://github.com/user-attachments/assets/53d84e16-6f77-4edb-8cdb-ecf4a1e319c7" />
