### PR TITLE
[AGE-473] pull new salesforce thread handler out

### DIFF
--- a/tiger_agent/app.py
+++ b/tiger_agent/app.py
@@ -6,6 +6,7 @@ from tiger_agent.tasks.handlers import (
     SalesforceAssignmentChangedHandler,
     SalesforceCreateCaseHandler,
     SalesforceFeedItemHandler,
+    SlackSalesforceCaseThreadMessageHandler,
     SlackTaskHandler,
 )
 from tiger_agent.agent.tiger_agent import TigerAgent
@@ -15,7 +16,7 @@ from tiger_agent.salesforce.types import (
     SalesforceCreateNewCaseEvent,
     SalesforceFeedItemEvent,
 )
-from tiger_agent.slack.types import SlackAppMentionEvent, SlackMessageEvent
+from tiger_agent.slack.types import SlackAppMentionEvent, SlackMessageEvent, SlackSalesforceCaseThreadMessageEvent
 from tiger_agent.tasks.handlers import TaskProcessor
 from tiger_agent.tasks.harness import TaskHarness
 from tiger_agent.types import HarnessContext
@@ -94,6 +95,7 @@ class TigerApp:
         processor.register(SalesforceAssignmentChangedEvent, SalesforceAssignmentChangedHandler(hctx=hctx, agent=agent))
         processor.register(SalesforceCreateNewCaseEvent, SalesforceCreateCaseHandler(hctx=hctx))
         processor.register(SalesforceFeedItemEvent, SalesforceFeedItemHandler(hctx=hctx))
+        processor.register(SlackSalesforceCaseThreadMessageEvent, SlackSalesforceCaseThreadMessageHandler(hctx=hctx))
 
         self._hctx = hctx
         self._listener_harness = ListenerHarness(hctx=hctx, task_processor=processor)

--- a/tiger_agent/listeners/slack.py
+++ b/tiger_agent/listeners/slack.py
@@ -4,7 +4,6 @@ from collections.abc import Sequence
 from typing import Any
 
 import logfire
-from pydantic_ai.messages import BinaryContent
 from slack_bolt.adapter.socket_mode.websockets import AsyncSocketModeHandler
 from slack_bolt.context.ack.async_ack import AsyncAck
 from slack_bolt.context.respond.async_respond import AsyncRespond
@@ -17,18 +16,11 @@ from tiger_agent.db.utils import (
     insert_handled_event,
 )
 from tiger_agent.listeners import Listener
-from tiger_agent.salesforce.constants import (
-    SALESFORCE_CASE_EMAIL_COMMENT_SUBJECT,
-    SALESFORCE_CASE_SUPPORT_EMAIL,
-    SALESFORCE_INTERNAL_FROM_NAME_SUFFIX,
-)
 from tiger_agent.salesforce.types import (
     AgentFeedbackRatingEvent,
     SalesforceCreateNewCaseEvent,
 )
 from tiger_agent.salesforce.utils import (
-    EmailAttachment,
-    add_case_email_comment,
     get_services_for_account,
 )
 from tiger_agent.slack.commands import (
@@ -43,12 +35,10 @@ from tiger_agent.slack.constants import (
     REJECT_PROACTIVE_PROMPT,
     SLACK_APP_TOKEN,
 )
-from tiger_agent.slack.types import BotInfo, SlackCommand, UserInfo
+from tiger_agent.slack.types import BotInfo, SlackCommand, SlackSalesforceCaseThreadMessageEvent, UserInfo
 from tiger_agent.slack.utils import (
-    download_private_file,
     fetch_bot_info,
     fetch_team_info,
-    fetch_user_info,
     handle_new_salesforce_case_workflow_form_cancel,
     handle_new_salesforce_case_workflow_form_submit,
     handle_proactive_prompt,
@@ -187,53 +177,18 @@ class SlackListener(Listener):
                 logfire.info("No text in Slack message, not syncing to Salesforce")
                 return
 
-            user_info = await fetch_user_info(self._app.client, user_id=user)
-            user_is_external = (
-                user_info.is_external or user_info.team_id != self._bot_info.team_id
+            await insert_event(
+                self._pool,
+                SlackSalesforceCaseThreadMessageEvent(
+                    user=user,
+                    channel=channel,
+                    thread_ts=thread_ts,
+                    text=text,
+                    salesforce_case_id=salesforce_case_id_for_slack_thread,
+                    files=files,
+                ).model_dump(),
             )
-            text_prefix, html_prefix = await self.get_reply_prefix_for_sender(user_info)
-
-            attachments: list[EmailAttachment] = []
-
-            for file in files:
-                type = file.get("mimetype")
-                url = file.get("url_private_download")
-                name = file.get("name")
-
-                file_content = await download_private_file(
-                    url_private_download=url,
-                )
-                if isinstance(file_content, BinaryContent):
-                    attachments.append(
-                        EmailAttachment(
-                            name=name,
-                            body=file_content.data,
-                            content_type=type,
-                        )
-                    )
-
-            add_case_email_comment(
-                self._hctx.salesforce_client,
-                case_id=salesforce_case_id_for_slack_thread,
-                body=f"{text_prefix}\n{text}",
-                html_body=f"<p>{html_prefix}</p><p>{text}</p>",
-                from_address=user_info.profile.email,
-                to_address=SALESFORCE_CASE_SUPPORT_EMAIL if user_is_external else None,
-                subject=SALESFORCE_CASE_EMAIL_COMMENT_SUBJECT,
-                from_name=f"{user_info.real_name} ({SALESFORCE_INTERNAL_FROM_NAME_SUFFIX})"
-                if not user_is_external
-                else None,
-                attachments=attachments if attachments else None,
-            )
-
-            logfire.info(
-                "Synced Slack message to Salesforce",
-                case_id=salesforce_case_id_for_slack_thread,
-                comment_body=text,
-                user_id=user,
-                user_name=user_info.real_name,
-                user_is_external=user_is_external,
-            )
+            await self._trigger.put(True)
 
         # if proactive prompting is enabled for channel and agent is not mentioned
         # then offer a proactive prompt

--- a/tiger_agent/slack/types.py
+++ b/tiger_agent/slack/types.py
@@ -242,3 +242,22 @@ class SlackMessageEvent(SlackBaseEvent):
 
     type: str = "message"
     subtype: str | None = None
+
+
+class SlackSalesforceCaseThreadMessageEvent(BaseModel):
+    """Event representing a Slack message posted in a thread linked to a Salesforce case.
+
+    Created by the listener when a non-bot message is posted in a thread that is
+    correlated to a Salesforce case. The handler syncs the message to Salesforce
+    as an email comment.
+    """
+
+    model_config = {"extra": "allow"}
+
+    type: str = "slack_salesforce_case_thread_message"
+    user: str
+    channel: str
+    thread_ts: str
+    text: str
+    salesforce_case_id: str
+    files: list[dict[str, Any]] = []

--- a/tiger_agent/tasks/handlers.py
+++ b/tiger_agent/tasks/handlers.py
@@ -12,6 +12,7 @@ from abc import ABC, abstractmethod
 import logfire
 from htmlslacker import HTMLSlacker
 from pydantic_ai import UsageLimits
+from pydantic_ai.messages import BinaryContent
 
 from tiger_agent.agent.tiger_agent import TigerAgent
 from tiger_agent.agent.utils import create_agent_and_context
@@ -24,7 +25,10 @@ from tiger_agent.db.utils import (
 )
 from tiger_agent.salesforce.constants import (
     SALESFORCE_CASE_CHANNEL,
+    SALESFORCE_CASE_EMAIL_COMMENT_SUBJECT,
+    SALESFORCE_CASE_SUPPORT_EMAIL,
     SALESFORCE_ENABLE_SPAM_FILTERING,
+    SALESFORCE_INTERNAL_FROM_NAME_SUFFIX,
     SALESFORCE_SLACK_CUSTOMER_THREAD_FIELD,
     SALESFORCE_SLACK_THREAD_FIELD,
 )
@@ -35,6 +39,8 @@ from tiger_agent.salesforce.types import (
     SalesforceFeedItemEvent,
 )
 from tiger_agent.salesforce.utils import (
+    EmailAttachment,
+    add_case_email_comment,
     create_case,
     create_case_url,
     download_feed_attachment,
@@ -44,9 +50,13 @@ from tiger_agent.slack.types import (
     SlackAppMentionEvent,
     SlackMessage,
     SlackMessageEvent,
+    SlackSalesforceCaseThreadMessageEvent,
 )
 from tiger_agent.slack.utils import (
     add_reaction,
+    download_private_file,
+    fetch_team_info,
+    fetch_user_info,
     post_response,
     send_feedback_rating_prompt,
     set_status,
@@ -394,4 +404,77 @@ class SalesforceFeedItemHandler(TaskHandler):
             text=text,
             use_mrkdwn=True,
             image_attachments=image_attachments,
+        )
+
+
+class SlackSalesforceCaseThreadMessageHandler(TaskHandler):
+    """Handles SlackSalesforceCaseThreadMessageEvent — no LLM required.
+
+    Syncs a Slack message posted in a Salesforce-linked thread back to the
+    Salesforce case as an email comment, including any file attachments.
+    """
+
+    @logfire.instrument("SlackSalesforceCaseThreadMessageHandler.handle", extract_args=False)
+    async def handle(self, task: Task) -> None:
+        hctx = self._hctx
+        event: SlackSalesforceCaseThreadMessageEvent = task.event
+
+        user_info = await fetch_user_info(hctx.app.client, user_id=event.user)
+        user_is_external = (
+            user_info.is_external or user_info.team_id != hctx.bot_info.team_id
+        )
+
+        # Build reply prefix with a link to the sender's Slack profile
+        in_same_team_as_bot = hctx.bot_info.team_id == user_info.team_id
+        profile_workspace_url: str | None = None
+        if in_same_team_as_bot:
+            profile_workspace_url = hctx.bot_info.url.strip("/")
+        else:
+            team_info = await fetch_team_info(hctx.app.client, team_id=user_info.team_id)
+            if team_info:
+                profile_workspace_url = f"https://{team_info.domain}.slack.com"
+
+        text_prefix = f"[Replied via Slack as @{user_info.name}]"
+        if profile_workspace_url:
+            user_profile_url = f"{profile_workspace_url}/team/{user_info.id}"
+            html_prefix = f'[Replied via Slack as <a href="{user_profile_url}">@{user_info.name}</a>]'
+        else:
+            html_prefix = text_prefix
+
+        attachments: list[EmailAttachment] = []
+        for file in event.files:
+            mimetype = file.get("mimetype")
+            url = file.get("url_private_download")
+            name = file.get("name")
+            file_content = await download_private_file(url_private_download=url)
+            if isinstance(file_content, BinaryContent):
+                attachments.append(
+                    EmailAttachment(
+                        name=name,
+                        body=file_content.data,
+                        content_type=mimetype,
+                    )
+                )
+
+        add_case_email_comment(
+            hctx.salesforce_client,
+            case_id=event.salesforce_case_id,
+            body=f"{text_prefix}\n{event.text}",
+            html_body=f"<p>{html_prefix}</p><p>{event.text}</p>",
+            from_address=user_info.profile.email,
+            to_address=SALESFORCE_CASE_SUPPORT_EMAIL if user_is_external else None,
+            subject=SALESFORCE_CASE_EMAIL_COMMENT_SUBJECT,
+            from_name=f"{user_info.real_name} ({SALESFORCE_INTERNAL_FROM_NAME_SUFFIX})"
+            if not user_is_external
+            else None,
+            attachments=attachments if attachments else None,
+        )
+
+        logfire.info(
+            "Synced Slack message to Salesforce",
+            case_id=event.salesforce_case_id,
+            comment_body=event.text,
+            user_id=event.user,
+            user_name=user_info.real_name,
+            user_is_external=user_is_external,
         )

--- a/tiger_agent/tasks/types.py
+++ b/tiger_agent/tasks/types.py
@@ -7,7 +7,11 @@ from tiger_agent.salesforce.types import (
     SalesforceCreateNewCaseEvent,
     SalesforceFeedItemEvent,
 )
-from tiger_agent.slack.types import SlackAppMentionEvent, SlackMessageEvent
+from tiger_agent.slack.types import (
+    SlackAppMentionEvent,
+    SlackMessageEvent,
+    SlackSalesforceCaseThreadMessageEvent,
+)
 
 
 class Task(BaseModel):
@@ -20,7 +24,7 @@ class Task(BaseModel):
         id: Primary key from agent.event table
         event_ts: Timestamp when the task was created
         attempts: Number of processing attempts made
-        vt: Visibility threshold - when task becomes available for processing
+        vt: Visibility timeout - when task becomes available for processing
         claimed: Array of timestamps when task was claimed by workers
         event: The original event payload
     """
@@ -33,6 +37,7 @@ class Task(BaseModel):
     event: (
         SlackAppMentionEvent
         | SlackMessageEvent
+        | SlackSalesforceCaseThreadMessageEvent
         | SalesforceCreateNewCaseEvent
         | SalesforceAssignmentChangedEvent
         | SalesforceFeedItemEvent


### PR DESCRIPTION
## What
This moves the Slack->Salesforce message syncing logic out of the `SlackListener` and into a new task handler. So, rather than doing all of the syncing logic when we receive the event from slack, we queue a new event into our db, then let a worker handle it async

## Why
Part of refactor epic