### PR TITLE
[AGE-474] Include all attachments and inline them

### DIFF
--- a/tiger_agent/listeners/slack.py
+++ b/tiger_agent/listeners/slack.py
@@ -35,7 +35,12 @@ from tiger_agent.slack.constants import (
     REJECT_PROACTIVE_PROMPT,
     SLACK_APP_TOKEN,
 )
-from tiger_agent.slack.types import BotInfo, SlackCommand, SlackSalesforceCaseThreadMessageEvent, UserInfo
+from tiger_agent.slack.types import (
+    BotInfo,
+    SlackCommand,
+    SlackSalesforceCaseThreadMessageEvent,
+    UserInfo,
+)
 from tiger_agent.slack.utils import (
     fetch_bot_info,
     fetch_team_info,

--- a/tiger_agent/salesforce/utils.py
+++ b/tiger_agent/salesforce/utils.py
@@ -202,6 +202,35 @@ def get_services_for_account(
     ]
 
 
+_INLINE_IMAGE_MIME_TYPES = {"image/png", "image/jpeg", "image/gif", "image/webp"}
+
+
+def _build_inline_html_body(
+    text_body: str,
+    uploaded: list[tuple[str, str, str]],  # (version_id, content_type, filename)
+) -> str:
+    """Build an HtmlBody that embeds uploaded attachments inline.
+
+    Images render as <img> via the Salesforce Shepherd download URL so that
+    screenshots appear in-place in the case timeline. Other file types render
+    as a download link.
+    """
+    import html
+
+    parts = ["<div>"]
+    for line in text_body.splitlines():
+        parts.append(f"<p>{html.escape(line)}</p>")
+    for version_id, content_type, filename in uploaded:
+        url = f"/sfc/servlet.shepherd/version/download/{version_id}"
+        name = html.escape(filename)
+        if content_type in _INLINE_IMAGE_MIME_TYPES:
+            parts.append(f'<p><img src="{url}" alt="{name}" style="max-width:100%;height:auto" /></p>')
+        else:
+            parts.append(f'<p><a href="{url}">{name}</a></p>')
+    parts.append("</div>")
+    return "".join(parts)
+
+
 def add_case_email_comment(
     salesforce_client: Salesforce,
     case_id: str,
@@ -214,6 +243,9 @@ def add_case_email_comment(
     html_body: str | None = None,
     attachments: list[EmailAttachment] | None = None,
 ) -> None:
+    import os
+
+    has_attachments = bool(attachments)
     payload = {
         "ParentId": case_id,
         "FromAddress": from_address,
@@ -223,7 +255,8 @@ def add_case_email_comment(
         "TextBody": body,
         "HtmlBody": html_body,
         "Incoming": incoming,
-        "Status": "0",  # 0 = "New"
+        # Keep in Draft (5) while uploading attachments; finalize to "0" (New) after.
+        "Status": "5" if has_attachments else "0",
     }
     result = salesforce_client.EmailMessage.create(payload)
     if not result["success"] or not result["id"]:
@@ -233,21 +266,78 @@ def add_case_email_comment(
         return
 
     email_message_id = result["id"]
+
+    # Track successfully uploaded versions for inline HTML body construction:
+    # (version_id, content_type, filename)
+    uploaded: list[tuple[str, str, str]] = []
+
     for attachment in attachments or []:
         encoded = base64.b64encode(attachment.body).decode("utf-8")
-        att_result = salesforce_client.Attachment.create(
+
+        # Strip extension from Title to avoid doubled extensions (e.g. "foo.png.png").
+        # Salesforce stores the extension separately in FileExtension.
+        name_without_ext = os.path.splitext(attachment.name)[0] or attachment.name
+
+        # Upload file as ContentVersion
+        cv_result = salesforce_client.ContentVersion.create(
             {
-                "ParentId": email_message_id,
-                "Name": attachment.name,
-                "ContentType": attachment.content_type,
-                "Body": encoded,
+                "Title": name_without_ext,
+                "PathOnClient": attachment.name,
+                "VersionData": encoded,
+                "IsMajorVersion": False,
             }
         )
-        if not att_result["success"] or not att_result["id"]:
+        if not cv_result["success"] or not cv_result["id"]:
             logfire.error(
-                "Could not attach file to Salesforce email message",
+                "Could not upload attachment as ContentVersion",
                 extra={"email_message_id": email_message_id, "name": attachment.name},
             )
+            continue
+
+        version_id = cv_result["id"]
+
+        # Retrieve the ContentDocumentId for the newly created ContentVersion
+        cv_record = salesforce_client.query(
+            f"SELECT ContentDocumentId FROM ContentVersion WHERE Id = '{version_id}'"
+        )
+        records = cv_record.get("records", [])
+        if not records:
+            logfire.error(
+                "Could not retrieve ContentDocumentId for ContentVersion",
+                extra={"content_version_id": version_id},
+            )
+            continue
+
+        content_document_id = records[0]["ContentDocumentId"]
+
+        # Link the ContentDocument to the EmailMessage
+        link_result = salesforce_client.ContentDocumentLink.create(
+            {
+                "ContentDocumentId": content_document_id,
+                "LinkedEntityId": email_message_id,
+                "ShareType": "V",
+                "Visibility": "AllUsers",
+            }
+        )
+        if not link_result["success"] or not link_result["id"]:
+            logfire.error(
+                "Could not link ContentDocument to EmailMessage",
+                extra={
+                    "email_message_id": email_message_id,
+                    "content_document_id": content_document_id,
+                },
+            )
+            continue
+
+        uploaded.append((version_id, attachment.content_type or "", attachment.name))
+
+    # Finalize: set Status to "0" (New) and write the inline HTML body so
+    # images appear in-place in the Salesforce case timeline.
+    if has_attachments:
+        inline_html = _build_inline_html_body(body, uploaded)
+        salesforce_client.EmailMessage.update(
+            email_message_id, {"Status": "0", "HtmlBody": inline_html}
+        )
 
 
 def get_recent_case_feed_items(
@@ -336,7 +426,9 @@ def download_feed_attachment(
         "File": "application/octet-stream",
         "Link": "text/uri-list",
     }
-    content_type = _ATTACHMENT_TYPE_TO_MIME.get(attachment_type, "application/octet-stream")
+    content_type = _ATTACHMENT_TYPE_TO_MIME.get(
+        attachment_type, "application/octet-stream"
+    )
 
     return FileAttachment(
         name=name,

--- a/tiger_agent/tasks/handlers.py
+++ b/tiger_agent/tasks/handlers.py
@@ -408,13 +408,15 @@ class SalesforceFeedItemHandler(TaskHandler):
 
 
 class SlackSalesforceCaseThreadMessageHandler(TaskHandler):
-    """Handles SlackSalesforceCaseThreadMessageEvent — no LLM required.
+    """Handles SlackSalesforceCaseThreadMessageEvent
 
     Syncs a Slack message posted in a Salesforce-linked thread back to the
     Salesforce case as an email comment, including any file attachments.
     """
 
-    @logfire.instrument("SlackSalesforceCaseThreadMessageHandler.handle", extract_args=False)
+    @logfire.instrument(
+        "SlackSalesforceCaseThreadMessageHandler.handle", extract_args=False
+    )
     async def handle(self, task: Task) -> None:
         hctx = self._hctx
         event: SlackSalesforceCaseThreadMessageEvent = task.event
@@ -430,7 +432,9 @@ class SlackSalesforceCaseThreadMessageHandler(TaskHandler):
         if in_same_team_as_bot:
             profile_workspace_url = hctx.bot_info.url.strip("/")
         else:
-            team_info = await fetch_team_info(hctx.app.client, team_id=user_info.team_id)
+            team_info = await fetch_team_info(
+                hctx.app.client, team_id=user_info.team_id
+            )
             if team_info:
                 profile_workspace_url = f"https://{team_info.domain}.slack.com"
 


### PR DESCRIPTION
## What
This adds more generic attachment support when syncing Slack case thread messages to Salesforce cases.

## Examples
__json snippet__

** Slack **
<img width="420" height="192" alt="image" src="https://github.com/user-attachments/assets/f25e0701-c5cb-41de-86c0-5aa573bcda57" />

** Salesforce **
<img width="412" height="210" alt="image" src="https://github.com/user-attachments/assets/70fa545d-5f3d-4756-b1af-a280f3a16e2b" />

__image__
**Slack**
<img width="548" height="369" alt="image" src="https://github.com/user-attachments/assets/1cffc106-75c9-4107-b91c-68142e0756a8" />

**Salesforce**
<img width="683" height="546" alt="image" src="https://github.com/user-attachments/assets/272696d6-6344-4b51-af2a-df252052efc4" />

