### PR TITLE
[AGE-475] Show Salesforce case status updates in Slack thread

### DIFF
--- a/tiger_agent/app.py
+++ b/tiger_agent/app.py
@@ -6,6 +6,7 @@ from tiger_agent.agent.tiger_agent import TigerAgent
 from tiger_agent.listeners.harness import ListenerHarness
 from tiger_agent.salesforce.types import (
     SalesforceAssignmentChangedEvent,
+    SalesforceCaseStatusChangedEvent,
     SalesforceCreateNewCaseEvent,
     SalesforceFeedItemEvent,
 )
@@ -16,6 +17,7 @@ from tiger_agent.slack.types import (
 )
 from tiger_agent.tasks.handlers import (
     SalesforceAssignmentChangedHandler,
+    SalesforceCaseStatusChangedHandler,
     SalesforceCreateCaseHandler,
     SalesforceFeedItemHandler,
     SlackSalesforceCaseThreadMessageHandler,
@@ -112,6 +114,10 @@ class TigerApp:
         processor.register(
             SlackSalesforceCaseThreadMessageEvent,
             SlackSalesforceCaseThreadMessageHandler(hctx=hctx),
+        )
+        processor.register(
+            SalesforceCaseStatusChangedEvent,
+            SalesforceCaseStatusChangedHandler(hctx=hctx),
         )
 
         self._hctx = hctx

--- a/tiger_agent/listeners/salesforce.py
+++ b/tiger_agent/listeners/salesforce.py
@@ -1,22 +1,30 @@
 import asyncio
 from asyncio import TaskGroup
+from collections.abc import Callable, Coroutine
 from datetime import datetime
+from typing import Any
 
 import logfire
 import schedule
 
-from tiger_agent.db.utils import insert_event, is_case_assignment_new
+from tiger_agent.db.utils import (
+    get_salesforce_case_thread_thread_id,
+    insert_event,
+    is_case_assignment_new,
+)
 from tiger_agent.listeners import Listener
 from tiger_agent.salesforce.case_feed_item_poller import SalesforceCaseFeedItemPoller
 from tiger_agent.salesforce.constants import (
     CASE_ID_FIELD,
     CASE_OWNER_ID_FIELD,
+    CASE_STATUS_FIELD,
     SALESFORCE_CASE_CHANNEL,
 )
 from tiger_agent.salesforce.new_case_poller import SalesforceNewCasePoller
 from tiger_agent.salesforce.types import (
     CaseData,
     SalesforceAssignmentChangedEvent,
+    SalesforceCaseStatusChangedEvent,
     SalesforceFeedItem,
     SalesforceFeedItemEvent,
 )
@@ -25,6 +33,9 @@ from tiger_agent.salesforce.utils import (
     subscribe_to_topic,
 )
 from tiger_agent.types import HarnessContext
+
+CASE_OWNER_CHANGED_TOPIC = "CaseOwnerChangedTopic"
+CASE_STATUS_CHANGED_TOPIC = "CaseStatusChangedTopic"
 
 
 class SalesforceListener(Listener):
@@ -51,7 +62,20 @@ class SalesforceListener(Listener):
             handler=self.handle_new_feed_item,
         )
 
-        tasks.create_task(self._subscribe_to_case_assignee_changed())
+        tasks.create_task(
+            self._subscribe_to_event(
+                CASE_OWNER_CHANGED_TOPIC,
+                [CASE_ID_FIELD, CASE_OWNER_ID_FIELD],
+                self.handle_updated_case_assignee,
+            )
+        )
+        tasks.create_task(
+            self._subscribe_to_event(
+                CASE_STATUS_CHANGED_TOPIC,
+                [CASE_ID_FIELD, CASE_STATUS_FIELD],
+                self.handle_case_status_changed,
+            )
+        )
         tasks.create_task(self._run_schedule())
 
         # poller will look for cases that have been created+assigned
@@ -134,22 +158,47 @@ class SalesforceListener(Listener):
 
         await self._trigger.put(True)
 
-    async def _subscribe_to_case_assignee_changed(self):
+    async def _subscribe_to_event(
+        self,
+        topic_name: str,
+        fields: list[str],
+        handler: Callable[[CaseData], Coroutine[Any, Any, None]],
+    ):
         try:
-            topic_name = "CaseOwnerChangedTopic"
             self._upsert_case_push_topic_definition(
                 topic_name=topic_name,
-                fields=[CASE_ID_FIELD, CASE_OWNER_ID_FIELD],
+                fields=fields,
                 notifyOnCreate=False,
                 notifyOnUpdate=True,
             )
             await subscribe_to_topic(
                 salesforce_client=self._salesforce_client,
                 topic_name=topic_name,
-                handler=self.handle_updated_case_assignee,
+                handler=handler,
             )
         except Exception:
-            logfire.exception("Error in subscribe_to_case_assignee_changed")
+            logfire.exception(f"Error subscribing to {topic_name}")
+
+    @logfire.instrument("handle_case_status_changed", extract_args=False)
+    async def handle_case_status_changed(self, case: CaseData):
+        result = await get_salesforce_case_thread_thread_id(self._pool, case_id=case.Id)
+
+        if not result:
+            # at present, we only care about Salesforce case status changes
+            # on cases that are correlated with Slack threads
+            return
+
+        full_case_data = self._salesforce_client.Case.get(case.Id)
+        [channel_id, thread_ts] = result
+        await insert_event(
+            pool=self._pool,
+            event=SalesforceCaseStatusChangedEvent(
+                case=full_case_data,
+                slack_thread_ts=thread_ts,
+                slack_channel_id=channel_id,
+            ).model_dump(),
+        )
+        await self._trigger.put(True)
 
     @logfire.instrument("handle_new_feed_item", extract_args=False)
     async def handle_new_feed_item(self, feed_item: SalesforceFeedItem):

--- a/tiger_agent/prompts/utils.py
+++ b/tiger_agent/prompts/utils.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 
 from tiger_agent.slack.types import BotInfo, SlackMessageEvent
+from tiger_agent.slack.utils import get_handle_link
 
 
 def format_thread_history(
@@ -25,9 +26,9 @@ def format_thread_history(
         if filter_message_ts and msg.ts in filter_message_ts:
             continue
         actor = (
-            f"<@{bot_info.user_id}> (you)"
+            f"{get_handle_link(bot_info.user_id)} (you)"
             if sender_id == bot_info.user_id
-            else f"<@{sender_id}>"
+            else get_handle_link(sender_id)
         )
         ts = datetime.fromtimestamp(float(msg.ts), tz=UTC).isoformat()
         lines.append(f"[{ts}] {actor}: {msg.text}")

--- a/tiger_agent/salesforce/constants.py
+++ b/tiger_agent/salesforce/constants.py
@@ -2,6 +2,7 @@ import os
 
 CASE_ID_FIELD = "Id"
 CASE_OWNER_ID_FIELD = "OwnerId"
+CASE_STATUS_FIELD = "Status"
 DEV_HELP_LINKS_FIELD = "Dev_Help_Links__c"
 
 CASE_FIELDS = [

--- a/tiger_agent/salesforce/types.py
+++ b/tiger_agent/salesforce/types.py
@@ -107,6 +107,16 @@ class SalesforceFeedItemEvent(SalesforceBaseEvent):
     feed_item: SalesforceFeedItem
 
 
+class SalesforceCaseStatusChangedEvent(SalesforceBaseEvent):
+    """Pydantic model for a Salesforce case closed event."""
+
+    type: str = "salesforce_event"
+    subtype: str = "case_status_changed"
+    case: CaseData
+    slack_thread_ts: str | None = None
+    slack_channel_id: str | None = None
+
+
 class AgentFeedbackRatingEvent(BaseModel):
     type: str = "agent_feedback_rating"
 

--- a/tiger_agent/slack/utils.py
+++ b/tiger_agent/slack/utils.py
@@ -12,7 +12,6 @@ All functions are designed to be resilient, gracefully handling API errors and p
 structured data models for Slack entities.
 """
 
-import os
 import re
 from collections.abc import Sequence
 from typing import Any
@@ -416,7 +415,8 @@ async def download_private_file(
             content_type_header = resp.headers.get("content-type", "")
             media_type = mimetype or (
                 content_type_header
-                if content_type_header and content_type_header != "application/force-download"
+                if content_type_header
+                and content_type_header != "application/force-download"
                 else "application/octet-stream"
             )
 
@@ -642,13 +642,13 @@ async def send_proactive_prompt(
     await client.chat_postEphemeral(
         channel=channel,
         user=user,
-        text=f"Hey <@{user}>, would you like me to assist you?",
+        text=f"Hey {get_handle_link(user)}, would you like me to assist you?",
         blocks=[
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"Hey <@{user}>, would you like me to assist you?",
+                    "text": f"Hey {get_handle_link(user)}, would you like me to assist you?",
                 },
             },
             {
@@ -693,7 +693,7 @@ async def send_feedback_rating_prompt(
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"Hey <@{user}>, how would you rate the helpfulness of my response?",
+                    "text": f"Hey{get_handle_link(user)}, how would you rate the helpfulness of my response?",
                 },
             },
             {
@@ -781,7 +781,7 @@ async def handle_proactive_prompt(
 
     await respond(
         response_type="ephemeral",
-        text=f"I will respond to your message now! For future reference, you can include <@{bot_info.user_id}> in a message and I will respond.",
+        text=f"I will respond to your message now! For future reference, you can include {get_handle_link(bot_info.user_id)} in a message and I will respond.",
         replace_original=True,
         delete_original=True,
     )
@@ -1019,3 +1019,11 @@ async def handle_new_salesforce_case_workflow_form_cancel(
     """
     await ack()
     await respond(text="", replace_original=True, delete_original=True)
+
+
+def add_quote_block(body: str) -> str:
+    return "\n".join(f"> {line}" for line in body.splitlines())
+
+
+def get_handle_link(user_id: str) -> str:
+    return f"<@{user_id}>"

--- a/tiger_agent/tasks/handlers.py
+++ b/tiger_agent/tasks/handlers.py
@@ -34,6 +34,7 @@ from tiger_agent.salesforce.constants import (
 from tiger_agent.salesforce.types import (
     SalesforceAssignmentChangedEvent,
     SalesforceBaseEvent,
+    SalesforceCaseStatusChangedEvent,
     SalesforceCreateNewCaseEvent,
     SalesforceFeedItemEvent,
 )
@@ -52,9 +53,11 @@ from tiger_agent.slack.types import (
     SlackSalesforceCaseThreadMessageEvent,
 )
 from tiger_agent.slack.utils import (
+    add_quote_block,
     add_reaction,
     fetch_team_info,
     fetch_user_info,
+    get_handle_link,
     post_response,
     send_feedback_rating_prompt,
     set_status,
@@ -123,8 +126,6 @@ class TaskProcessor:
 
 
 class SlackTaskHandler(TaskHandler):
-    """Handles SlackAppMentionEvent and SlackMessageEvent via LLM."""
-
     def __init__(self, hctx: HarnessContext, agent: TigerAgent) -> None:
         super().__init__(hctx)
         self._agent = agent
@@ -203,8 +204,7 @@ class SlackTaskHandler(TaskHandler):
 
 
 class SalesforceAssignmentChangedHandler(TaskHandler):
-    """Handles SalesforceAssignmentChangedEvent
-
+    """
     Runs the agent to produce a case summary and posts it to the Salesforce
     case channel. Updates the Salesforce case with the Slack thread permalink.
     """
@@ -243,7 +243,7 @@ class SalesforceAssignmentChangedHandler(TaskHandler):
             client=hctx.app.client,
             channel=SALESFORCE_CASE_CHANNEL,
             thread_ts=None,
-            text=f"*New Case* <{create_case_url(event.case)}|{event.case.CaseNumber}> - _{event.case.Subject}_{f', assigned to <@{response.output.case_owner_slack_user_id}>' if response.output.case_owner_slack_user_id else ''}:thread: \n```\n{response.output.short_description_of_case}\n```",
+            text=f"*New Case* <{create_case_url(event.case)}|{event.case.CaseNumber}> - _{event.case.Subject}_{f', assigned to {get_handle_link(response.output.case_owner_slack_user_id)}' if response.output.case_owner_slack_user_id else ''}:thread: \n```\n{response.output.short_description_of_case}\n```",
         )
 
         message_to_link_to = SlackMessage(
@@ -290,8 +290,7 @@ class SalesforceAssignmentChangedHandler(TaskHandler):
 
 
 class SalesforceCreateCaseHandler(TaskHandler):
-    """Handles SalesforceCreateNewCaseEvent
-
+    """
     Creates a Salesforce case from a Slack-initiated form submission and posts
     a confirmation message to the originating channel.
     """
@@ -327,7 +326,8 @@ class SalesforceCreateCaseHandler(TaskHandler):
             client=hctx.app.client,
             channel=channel_to_respond,
             thread_ts=None,
-            text=f"*Support Case Created*\nCase Number: {new_case.CaseNumber}\nSubject: {new_case.Subject} \nDescription: {new_case.Description}",
+            text=f"*Support Case Created*\n_Submitter:_ {get_handle_link(event.user)}\n_Case Number:_ `{new_case.CaseNumber}`\n_Subject:_ `{new_case.Subject}` \n_Description:_\n{add_quote_block(new_case.Description)}",
+            use_mrkdwn=True,
         )
 
         new_case_thread_ts = response.data.get("ts", None)
@@ -366,9 +366,8 @@ class SalesforceCreateCaseHandler(TaskHandler):
 
 
 class SalesforceFeedItemHandler(TaskHandler):
-    """Handles SalesforceFeedItemEvent — no LLM required.
-
-    Syncs a Salesforce Chatter post on a case to the linked Slack thread.
+    """
+    Syncs a Salesforce post on a case to the linked Slack thread.
     """
 
     @logfire.instrument("SalesforceFeedItemHandler.handle", extract_args=False)
@@ -380,7 +379,7 @@ class SalesforceFeedItemHandler(TaskHandler):
         )
 
         markdown_conversion = HTMLSlacker(event.feed_item.Body).get_output().strip()
-        body = "\n".join(f"> {line}" for line in markdown_conversion.splitlines())
+        body = add_quote_block(markdown_conversion)
         text = f"_From_ *{event.feed_item.CreatedBy.Name}* _via Tigerdata Support_\n\n{body}"
 
         attachment_ids = get_feed_attachment_ids(
@@ -402,8 +401,7 @@ class SalesforceFeedItemHandler(TaskHandler):
 
 
 class SlackSalesforceCaseThreadMessageHandler(TaskHandler):
-    """Handles SlackSalesforceCaseThreadMessageEvent
-
+    """
     Syncs a Slack message posted in a Salesforce-linked thread back to the
     Salesforce case as an email comment, including any file attachments.
     """
@@ -464,4 +462,22 @@ class SlackSalesforceCaseThreadMessageHandler(TaskHandler):
             user_id=event.user,
             user_name=user_info.real_name,
             user_is_external=user_is_external,
+        )
+
+
+class SalesforceCaseStatusChangedHandler(TaskHandler):
+    """
+    Called when a Salesforce case status changes.
+    """
+
+    @logfire.instrument("SalesforceCaseStatusChangedHandler.handle", extract_args=False)
+    async def handle(self, task: Task) -> None:
+        hctx = self._hctx
+        event: SalesforceCaseStatusChangedEvent = task.event
+
+        await post_response(
+            client=hctx.app.client,
+            channel=event.slack_channel_id,
+            thread_ts=event.slack_thread_ts,
+            text=f"_Case status updated to_ `{event.case.Status}`",
         )

--- a/tiger_agent/tasks/types.py
+++ b/tiger_agent/tasks/types.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 
 from tiger_agent.salesforce.types import (
     SalesforceAssignmentChangedEvent,
+    SalesforceCaseStatusChangedEvent,
     SalesforceCreateNewCaseEvent,
     SalesforceFeedItemEvent,
 )
@@ -41,4 +42,5 @@ class Task(BaseModel):
         | SalesforceCreateNewCaseEvent
         | SalesforceAssignmentChangedEvent
         | SalesforceFeedItemEvent
+        | SalesforceCaseStatusChangedEvent
     )


### PR DESCRIPTION
## What
* when Salesforce case's status changes, post the update in the Slack thread (if there is a correlated one)

<img width="401" height="117" alt="image" src="https://github.com/user-attachments/assets/b9eac61d-3851-46eb-a0be-6ae389d9cbfe" />

* add a link to the submitter of a ticket and add some more formatting style to the new ticket
<img width="297" height="236" alt="image" src="https://github.com/user-attachments/assets/fff2ca2d-e28c-41b3-b177-829ff05a68c0" />


Note: if a new message is sent to a case that is closed, Salesforce will automatically re-open with status of `Waiting on Timescale`
