### PR TITLE
[AGE-476] handle inline images and file attachments from salesforce

### DIFF
--- a/tiger_agent/salesforce/types.py
+++ b/tiger_agent/salesforce/types.py
@@ -130,3 +130,16 @@ class AgentFeedbackRatingEvent(BaseModel):
 class ServiceRecord:
     service_id: str
     project_id: str | None
+
+
+class ContentVersion(BaseModel):
+    """Pydantic model for a Salesforce ContentVersion record."""
+
+    model_config = {"extra": "allow"}
+
+    Id: str
+    Title: str | None = None
+    FileExtension: str | None = None
+    VersionData: str | None = None
+    ContentDocumentId: str | None = None
+    IsLatest: bool | None = None

--- a/tiger_agent/salesforce/utils.py
+++ b/tiger_agent/salesforce/utils.py
@@ -37,6 +37,14 @@ IGNORED_CONTACT_EMAILS = set(
     .split(",")
 )
 
+EXT_TO_MIME = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "webp": "image/webp",
+}
+
 logfire.info("Salesforce ignore list", extra={"list": IGNORED_CONTACT_EMAILS})
 
 
@@ -396,62 +404,100 @@ def get_feed_attachment_ids(
     return [r["Id"] for r in result.get("records", [])]
 
 
+@logfire.instrument("download_feed_attachment {feed_attachment_id=}")
 def download_feed_attachment(
     salesforce_client: Salesforce,
     feed_attachment_id: str,
-) -> FileAttachment:
+) -> FileAttachment | None:
     """Download the body of a Salesforce FeedAttachment by its Id.
 
-    FeedAttachment records link a ContentDocument to a FeedItem. The binary
-    content is fetched from the ContentVersion REST endpoint.
+    Handles three attachment types:
+    - Content/File: fetched via ContentVersion.VersionData, falling back to
+      ContentDocument.Body if no ContentVersion exists.
+    - Attachment: fetched via the legacy Attachment.Body REST endpoint.
+    - Link: no body to download, returns None.
     """
-    attachment = salesforce_client.FeedAttachment.get(feed_attachment_id)
-    record_id = attachment.get("RecordId")
-    if not record_id:
-        raise ValueError(f"FeedAttachment {feed_attachment_id} has no RecordId")
-    attachment_type = attachment.get("Type", "")
+    try:
+        attachment = salesforce_client.FeedAttachment.get(feed_attachment_id)
+        record_id = attachment.get("RecordId")
+        attachment_type = attachment.get("Type", "")
 
-    version = salesforce_client.query(
-        f"SELECT Id, Title, FileExtension, VersionData"
-        f" FROM ContentVersion"
-        f" WHERE ContentDocumentId = '{record_id}'"
-        f" AND IsLatest = true"
-        f" LIMIT 1"
-    )
-    records = version.get("records", [])
-    if not records:
-        raise ValueError(f"No ContentVersion found for ContentDocument {record_id}")
+        if attachment_type == "Link":
+            return None
 
-    cv = records[0]
-    url = f"https://{salesforce_client.sf_instance}{cv['VersionData']}"
-    response = salesforce_client.session.get(
-        url,
-        headers={
-            "Authorization": f"Bearer {salesforce_client.session_id}",
-            "Accept": "*/*",
-        },
-    )
-    response.raise_for_status()
+        if not record_id:
+            raise ValueError(f"FeedAttachment {feed_attachment_id} has no RecordId")
 
-    name = cv.get("Title") or feed_attachment_id
-    extension = cv.get("FileExtension")
-    if extension:
-        name = f"{name}.{extension}"
+        match attachment_type:
+            # Legacy Attachment object — body lives directly on the Attachment record
+            case "Attachment":
+                att = salesforce_client.query(
+                    f"SELECT Name FROM Attachment WHERE Id = '{record_id}' LIMIT 1"
+                )
+                att_records = att.get("records", [])
+                name = att_records[0].get("Name") if att_records else feed_attachment_id
+                url = f"https://{salesforce_client.sf_instance}/services/data/v59.0/sobjects/Attachment/{record_id}/Body"
+                content_type = "application/octet-stream"
+            case "InlineImage":
+                # InlineImage: RecordId is a ContentDocument.Id, look up via ContentVersion
+                version = salesforce_client.query(
+                    f"SELECT Id, Title, FileExtension, FileType, VersionData"
+                    f" FROM ContentVersion"
+                    f" WHERE ContentDocumentId = '{record_id}'"
+                    f" AND IsLatest = true"
+                    f" LIMIT 1"
+                )
+                records = version.get("records", [])
+                if not records:
+                    raise ValueError(
+                        f"No ContentVersion found for ContentDocument {record_id}"
+                    )
+                cv = records[0]
+                url = f"https://{salesforce_client.sf_instance}{cv['VersionData']}"
+                name = cv.get("Title") or feed_attachment_id
+                extension = cv.get("FileExtension")
+                if extension:
+                    name = f"{name}.{extension}"
 
-    _ATTACHMENT_TYPE_TO_MIME = {
-        "InlineImage": "image/png",
-        "File": "application/octet-stream",
-        "Link": "text/uri-list",
-    }
-    content_type = _ATTACHMENT_TYPE_TO_MIME.get(
-        attachment_type, "application/octet-stream"
-    )
+                content_type = EXT_TO_MIME.get(
+                    (extension or "").lower(), "application/octet-stream"
+                )
+            case "Content":
+                # Content/File: RecordId is a ContentVersion.Id directly
+                cv = salesforce_client.ContentVersion.get(record_id)
+                url = f"https://{salesforce_client.sf_instance}{cv['VersionData']}"
+                name = cv.get("Title") or feed_attachment_id
+                extension = cv.get("FileExtension")
+                if extension:
+                    name = f"{name}.{extension}"
+                content_type = "application/octet-stream"
+            case _:
+                logfire.warn(
+                    "Unexpected attachment type, ignoring",
+                    attachment_type=attachment_type,
+                )
+                return None
 
-    return FileAttachment(
-        name=name,
-        body=response.content,
-        content_type=content_type,
-    )
+        response = salesforce_client.session.get(
+            url,
+            headers={
+                "Authorization": f"Bearer {salesforce_client.session_id}",
+                "Accept": "*/*",
+            },
+        )
+        response.raise_for_status()
+
+        return FileAttachment(
+            name=name,
+            body=response.content,
+            content_type=content_type,
+        )
+    except Exception:
+        logfire.exception(
+            "Failed to download feed attachment, skipping",
+            feed_attachment_id=feed_attachment_id,
+        )
+        return None
 
 
 def get_project_ids_for_account(

--- a/tiger_agent/salesforce/utils.py
+++ b/tiger_agent/salesforce/utils.py
@@ -21,6 +21,7 @@ from tiger_agent.salesforce.constants import (
 )
 from tiger_agent.salesforce.types import (
     CaseData,
+    ContentVersion,
     EmailAttachment,
     FileAttachment,
     SalesforceFeedItem,
@@ -427,24 +428,20 @@ def download_feed_attachment(
 
         if not record_id:
             raise ValueError(f"FeedAttachment {feed_attachment_id} has no RecordId")
-
+        content_version: ContentVersion | None = None
         match attachment_type:
-            # Legacy Attachment object — body lives directly on the Attachment record
-            case "Attachment":
-                att = salesforce_client.query(
-                    f"SELECT Name FROM Attachment WHERE Id = '{record_id}' LIMIT 1"
+            case "Content":
+                # Content: RecordId is a ContentVersion.Id directly
+                content_version = ContentVersion.model_validate(
+                    salesforce_client.ContentVersion.get(record_id)
                 )
-                att_records = att.get("records", [])
-                name = att_records[0].get("Name") if att_records else feed_attachment_id
-                url = f"https://{salesforce_client.sf_instance}/services/data/v59.0/sobjects/Attachment/{record_id}/Body"
-                content_type = "application/octet-stream"
+
             case "InlineImage":
-                # InlineImage: RecordId is a ContentDocument.Id, look up via ContentVersion
+                # InlineImage: RecordId is a ContentDocument.Id
                 version = salesforce_client.query(
-                    f"SELECT Id, Title, FileExtension, FileType, VersionData"
+                    f"SELECT Id, Title, FileExtension, VersionData, ContentDocumentId"
                     f" FROM ContentVersion"
-                    f" WHERE ContentDocumentId = '{record_id}'"
-                    f" AND IsLatest = true"
+                    f" WHERE ContentDocumentId = '{record_id}' AND IsLatest = true"
                     f" LIMIT 1"
                 )
                 records = version.get("records", [])
@@ -452,25 +449,8 @@ def download_feed_attachment(
                     raise ValueError(
                         f"No ContentVersion found for ContentDocument {record_id}"
                     )
-                cv = records[0]
-                url = f"https://{salesforce_client.sf_instance}{cv['VersionData']}"
-                name = cv.get("Title") or feed_attachment_id
-                extension = cv.get("FileExtension")
-                if extension:
-                    name = f"{name}.{extension}"
+                content_version = ContentVersion.model_validate(records[0])
 
-                content_type = EXT_TO_MIME.get(
-                    (extension or "").lower(), "application/octet-stream"
-                )
-            case "Content":
-                # Content/File: RecordId is a ContentVersion.Id directly
-                cv = salesforce_client.ContentVersion.get(record_id)
-                url = f"https://{salesforce_client.sf_instance}{cv['VersionData']}"
-                name = cv.get("Title") or feed_attachment_id
-                extension = cv.get("FileExtension")
-                if extension:
-                    name = f"{name}.{extension}"
-                content_type = "application/octet-stream"
             case _:
                 logfire.warn(
                     "Unexpected attachment type, ignoring",
@@ -478,6 +458,14 @@ def download_feed_attachment(
                 )
                 return None
 
+        url = f"https://{salesforce_client.sf_instance}{content_version.VersionData}"
+        name = content_version.Title or feed_attachment_id
+        extension = content_version.FileExtension
+        if extension:
+            name = f"{name}.{extension}"
+        content_type = EXT_TO_MIME.get(
+            (extension or "").lower(), "application/octet-stream"
+        )
         response = salesforce_client.session.get(
             url,
             headers={

--- a/tiger_agent/slack/commands.py
+++ b/tiger_agent/slack/commands.py
@@ -18,6 +18,7 @@ from tiger_agent.salesforce.constants import (
 from tiger_agent.salesforce.types import SalesforceAssignmentChangedEvent
 from tiger_agent.slack.types import BotInfo, SlackCommand
 from tiger_agent.slack.utils import (
+    get_handle_link,
     parse_slack_url,
     parse_slack_user_name,
     send_new_case_button,

--- a/tiger_agent/slack/utils.py
+++ b/tiger_agent/slack/utils.py
@@ -233,14 +233,14 @@ async def fetch_thread_messages(
         return []
 
 
-@logfire.instrument("post_response", extract_args=["channel", "thread_ts"])
+@logfire.instrument("post_response", extract_args=["channel", "thread_ts", "text"])
 async def post_response(
     client: AsyncWebClient,
     channel: str,
     thread_ts: str | None,
     text: str,
     use_mrkdwn: bool = False,
-    image_attachments: list[FileAttachment] | None = None,
+    file_attachments: list[FileAttachment] | None = None,
 ) -> AsyncSlackResponse:
     """Post a response message to Slack with rich formatting.
 
@@ -269,9 +269,7 @@ async def post_response(
         unfurl_media=False,
     )
 
-    for attachment in image_attachments or []:
-        if not attachment.content_type.startswith("image/"):
-            continue
+    for attachment in file_attachments or []:
         await client.files_upload_v2(
             channel=channel,
             thread_ts=thread_ts,

--- a/tiger_agent/tasks/handlers.py
+++ b/tiger_agent/tasks/handlers.py
@@ -371,7 +371,7 @@ class SalesforceFeedItemHandler(TaskHandler):
     Syncs a Salesforce Chatter post on a case to the linked Slack thread.
     """
 
-    @logfire.instrument("SalesforceFeedItemHandler.handle", extract_args=False)
+    @logfire.instrument("SalesforceFeedItemHandler.handle", extract_args=["task"])
     async def handle(self, task: Task) -> None:
         hctx = self._hctx
         event: SalesforceFeedItemEvent = task.event
@@ -386,9 +386,10 @@ class SalesforceFeedItemHandler(TaskHandler):
         attachment_ids = get_feed_attachment_ids(
             hctx.salesforce_client, event.feed_item.Id
         )
-        image_attachments = [
-            download_feed_attachment(hctx.salesforce_client, aid)
+        file_attachments = [
+            a
             for aid in attachment_ids
+            if (a := download_feed_attachment(hctx.salesforce_client, aid)) is not None
         ]
 
         await post_response(
@@ -397,7 +398,7 @@ class SalesforceFeedItemHandler(TaskHandler):
             thread_ts=thread_ts,
             text=text,
             use_mrkdwn=True,
-            image_attachments=image_attachments,
+            file_attachments=file_attachments,
         )
 
 


### PR DESCRIPTION
## What
This adds support for all attachments made on a Salesforce case comment. Previously, only inline images were supported.

## How
The Salesforce attachment schema is a bit confusing. 

_Downloading an InlineImage attachment_
* find the `ContentVersion` by matching the `ContentDocumentId` with the `FeedAttachment`'s id
* download the `ContentVersion`

_Downloading Content attachment_
* find the `ContentVersion` that has the *same* ID as the `FeedAttachment`
* download the `ContentVersion`


## Example
<img width="849" height="860" alt="image" src="https://github.com/user-attachments/assets/dccf00c9-3070-47f2-b12f-1d38b9d5a1f9" />

[Link](https://iobeam.slack.com/archives/C09DL0P0XGS/p1777572662994369?thread_ts=1777492799.082589&cid=C09DL0P0XGS)