### PR TITLE
[AGE-477] only notify on fields in the select

### DIFF
--- a/tiger_agent/listeners/salesforce.py
+++ b/tiger_agent/listeners/salesforce.py
@@ -102,7 +102,7 @@ class SalesforceListener(Listener):
             "NotifyForOperationUpdate": notifyOnUpdate,
             "NotifyForOperationUndelete": False,
             "NotifyForOperationDelete": False,
-            "NotifyForFields": "Referenced",
+            "NotifyForFields": "Select",
         }
 
         results = self._salesforce_client.query(


### PR DESCRIPTION
## What
This changes the `NotifyForFields` on our push topics to `Select`, rather than `Referenced`. This causes the events only to be published if a field in the actual query updates. [See doc](https://developer.salesforce.com/docs/atlas.en-us.api_streaming.meta/api_streaming/notifyforfields_select.htm)

## Why
We do not want duplicate events, such as 
<img width="298" height="123" alt="image" src="https://github.com/user-attachments/assets/ea058b51-eba6-41e4-95d2-85336a91c0df" />
