### PR TITLE
[AGE-479] use links to profiles in salesforce message

### DIFF
--- a/tiger_agent/salesforce/utils.py
+++ b/tiger_agent/salesforce/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import os
+import re
 from collections.abc import Callable, Coroutine
 from typing import Any
 
@@ -28,7 +29,12 @@ from tiger_agent.salesforce.types import (
     ServiceRecord,
 )
 from tiger_agent.slack.types import SlackBaseEvent, SlackFile
-from tiger_agent.slack.utils import download_private_file
+from tiger_agent.slack.utils import (
+    download_private_file,
+    fetch_user_info,
+    get_a_href_link_to_user_profile,
+)
+from tiger_agent.types import HarnessContext
 
 RECONNECT_DELAY_SECONDS = 30
 IGNORED_CONTACT_EMAILS = set(
@@ -541,3 +547,29 @@ async def build_email_attachments_from_slack_files(
             )
         )
     return attachments
+
+
+async def replace_all_slack_mentions_with_links_to_profile(
+    hctx: HarnessContext, message: str
+) -> tuple[str, str]:
+    """
+    This will replace all of the <@U....> app mentions with html links to the profiles.
+    It returns an html version (e.g. with the a hrefs) and a non html version (with just the @user.name)
+    """
+
+    html = f"{message}"
+    non_html = f"{message}"
+
+    matches = re.findall(r"<@(U[A-Z0-9]{10})>", message)
+
+    for match in matches:
+        user_info = await fetch_user_info(client=hctx.app.client, user_id=match)
+
+        link_to_user_profile = await get_a_href_link_to_user_profile(
+            hctx=hctx, user_info=user_info
+        )
+
+        html = html.replace(f"<@{match}>", link_to_user_profile)
+        non_html = non_html.replace(f"<@{match}>", f"@{user_info.name}")
+
+    return (html, non_html)

--- a/tiger_agent/slack/utils.py
+++ b/tiger_agent/slack/utils.py
@@ -58,6 +58,7 @@ from tiger_agent.slack.types import (
     TeamInfo,
     UserInfo,
 )
+from tiger_agent.types import HarnessContext
 from tiger_agent.utils import file_type_supported
 
 
@@ -1025,3 +1026,36 @@ def add_quote_block(body: str) -> str:
 
 def get_handle_link(user_id: str) -> str:
     return f"<@{user_id}>"
+
+
+def user_is_external(bot_info: BotInfo, user_info: UserInfo) -> bool:
+    # seemingly you can't trust Slacks' is_external fields
+    # so this is going to compare the user's team with
+    # the bots team (which we will assume is the home team, as it were)
+
+    in_same_team_as_bot = bot_info.team_id == user_info.team_id
+    return (
+        user_info.is_external
+        or user_info.is_restricted
+        or user_info.is_stranger
+        or user_info.is_ultra_restricted
+        or not in_same_team_as_bot
+    )
+
+
+async def get_a_href_link_to_user_profile(
+    hctx: HarnessContext, user_info: UserInfo
+) -> str | None:
+    profile_workspace_url: str | None = None
+    if user_is_external(bot_info=hctx.bot_info, user_info=user_info):
+        team_info = await fetch_team_info(hctx.app.client, team_id=user_info.team_id)
+        if team_info:
+            profile_workspace_url = f"https://{team_info.domain}.slack.com"
+    else:
+        profile_workspace_url = hctx.bot_info.url.strip("/")
+
+    if profile_workspace_url:
+        user_profile_url = f"{profile_workspace_url}/team/{user_info.id}"
+        return f'<a href="{user_profile_url}">@{user_info.name}</a>'
+
+    return f"@{user_info.name}"

--- a/tiger_agent/tasks/handlers.py
+++ b/tiger_agent/tasks/handlers.py
@@ -45,6 +45,7 @@ from tiger_agent.salesforce.utils import (
     create_case_url,
     download_feed_attachment,
     get_feed_attachment_ids,
+    replace_all_slack_mentions_with_links_to_profile,
 )
 from tiger_agent.slack.types import (
     SlackAppMentionEvent,
@@ -55,13 +56,14 @@ from tiger_agent.slack.types import (
 from tiger_agent.slack.utils import (
     add_quote_block,
     add_reaction,
-    fetch_team_info,
     fetch_user_info,
+    get_a_href_link_to_user_profile,
     get_handle_link,
     post_response,
     send_feedback_rating_prompt,
     set_status,
     stream_response_to_mention,
+    user_is_external,
 )
 from tiger_agent.tasks.types import Task
 from tiger_agent.types import HarnessContext
@@ -415,43 +417,35 @@ class SlackSalesforceCaseThreadMessageHandler(TaskHandler):
         event: SlackSalesforceCaseThreadMessageEvent = task.event
 
         user_info = await fetch_user_info(hctx.app.client, user_id=event.user)
-        user_is_external = (
-            user_info.is_external or user_info.team_id != hctx.bot_info.team_id
+        is_external_user = user_is_external(bot_info=hctx.bot_info, user_info=user_info)
+        link_to_user_profile = await get_a_href_link_to_user_profile(
+            hctx=hctx, user_info=user_info
         )
 
-        # Build reply prefix with a link to the sender's Slack profile
-        in_same_team_as_bot = hctx.bot_info.team_id == user_info.team_id
-        profile_workspace_url: str | None = None
-        if in_same_team_as_bot:
-            profile_workspace_url = hctx.bot_info.url.strip("/")
-        else:
-            team_info = await fetch_team_info(
-                hctx.app.client, team_id=user_info.team_id
-            )
-            if team_info:
-                profile_workspace_url = f"https://{team_info.domain}.slack.com"
-
         text_prefix = f"[Replied via Slack as @{user_info.name}]"
-        if profile_workspace_url:
-            user_profile_url = f"{profile_workspace_url}/team/{user_info.id}"
-            html_prefix = f'[Replied via Slack as <a href="{user_profile_url}">@{user_info.name}</a>]'
-        else:
-            html_prefix = text_prefix
+        html_prefix = f"[Replied via Slack as {link_to_user_profile}</a>]"
 
         attachments = await build_email_attachments_from_slack_files(
             client=hctx.app.client, event=event
         )
 
+        [
+            html_message_body,
+            plain_message_body,
+        ] = await replace_all_slack_mentions_with_links_to_profile(
+            hctx=hctx, message=event.text
+        )
+
         add_case_email_comment(
             hctx.salesforce_client,
             case_id=event.salesforce_case_id,
-            body=f"{text_prefix}\n{event.text}",
-            html_body=f"<p>{html_prefix}</p><p>{event.text}</p>",
+            body=f"{text_prefix}\n{plain_message_body}",
+            html_body=f"<p>{html_prefix}</p><p>{html_message_body}</p>",
             from_address=user_info.profile.email,
-            to_address=SALESFORCE_CASE_SUPPORT_EMAIL if user_is_external else None,
+            to_address=SALESFORCE_CASE_SUPPORT_EMAIL if is_external_user else None,
             subject=SALESFORCE_CASE_EMAIL_COMMENT_SUBJECT,
             from_name=f"{user_info.real_name} ({SALESFORCE_INTERNAL_FROM_NAME_SUFFIX})"
-            if not user_is_external
+            if not is_external_user
             else None,
             attachments=attachments if attachments else None,
         )
@@ -462,7 +456,7 @@ class SlackSalesforceCaseThreadMessageHandler(TaskHandler):
             comment_body=event.text,
             user_id=event.user,
             user_name=user_info.real_name,
-            user_is_external=user_is_external,
+            user_is_external=is_external_user,
         )
 
 


### PR DESCRIPTION
## What
When syncing a Slack message that has an app mention, we should create links to the Slack user profile and display with @username.

## Why
Request here https://iobeam.slack.com/archives/C0AURFDFY2G/p1777578131851879?thread_ts=1777576899.110389&cid=C0AURFDFY2G

## Demo
<img width="444" height="157" alt="image" src="https://github.com/user-attachments/assets/c23f6b74-1bc3-4f9e-9617-cea51c1b1357" />
