### PR TITLE
[AGE-484] Use modal for feedback input from support engineers

### DIFF
--- a/tiger_agent/listeners/slack.py
+++ b/tiger_agent/listeners/slack.py
@@ -1,6 +1,6 @@
+import json
 import re
 from asyncio import TaskGroup
-from collections.abc import Sequence
 from typing import Any
 
 import logfire
@@ -28,7 +28,6 @@ from tiger_agent.slack.commands import (
     handle_command,
 )
 from tiger_agent.slack.constants import (
-    AGENT_FEEDBACK_RATING,
     CONFIRM_PROACTIVE_PROMPT,
     FEEDBACK_FORM_SUBMIT,
     FEEDBACK_FORM_TRIGGER,
@@ -94,7 +93,7 @@ class SlackListener(Listener):
         self._hctx.bot_info = self._bot_info
         self._app.action(CONFIRM_PROACTIVE_PROMPT)(self._handle_proactive_prompt)
         self._app.action(REJECT_PROACTIVE_PROMPT)(self._handle_proactive_prompt)
-        self._app.action(AGENT_FEEDBACK_RATING)(self._handle_agent_feedback_rating)
+
         self._app.action(NEW_SALESFORCE_CASE_WORKFLOW_FORM_SUBMIT)(
             self._handle_new_salesforce_case_workflow_form_submit
         )
@@ -307,15 +306,22 @@ class SlackListener(Listener):
         channel = body.get("channel", {}).get("id")
         if not trigger_id:
             return
+        action_value = body.get("actions", [{}])[0].get("value")
+        thread_ts = json.loads(action_value).get("thread_ts") if action_value else None
         await send_feedback_form(
-            client=self._app.client, trigger_id=trigger_id, channel=channel
+            client=self._app.client,
+            trigger_id=trigger_id,
+            channel=channel,
+            thread_ts=thread_ts,
         )
 
     async def _handle_feedback_form_submit(self, ack: AsyncAck, body: dict[str, Any]):
         await ack()
         view = body.get("view", {})
         values = view.get("state", {}).get("values", {})
-        channel = view.get("private_metadata") or None
+        metadata = json.loads(view.get("private_metadata") or "{}")
+        channel = metadata.get("channel")
+        message_ts = metadata.get("thread_ts")
         user_id = body.get("user", {}).get("id")
         user_info = await fetch_user_info(client=self._app.client, user_id=user_id)
 
@@ -324,7 +330,8 @@ class SlackListener(Listener):
         rating = (
             values.get("rating_block", {})
             .get("rating_input", {})
-            .get("selected_option") or {}
+            .get("selected_option")
+            or {}
         ).get("value")
         description = (
             values.get("description_block", {})
@@ -342,6 +349,7 @@ class SlackListener(Listener):
                 user=user_id,
                 channel=channel,
                 rating=int(rating) if rating else None,
+                message_ts=message_ts,
             ).model_dump(),
         )
 
@@ -372,64 +380,3 @@ class SlackListener(Listener):
             return
 
         await process_task(self._task_processor, self._hctx, event)
-
-    async def _handle_agent_feedback_rating(
-        self, ack: AsyncAck, body: dict[str, Any], respond: AsyncRespond
-    ):
-        await ack()
-
-        actions = body.get("actions")
-        if actions is None or not isinstance(actions, Sequence) or len(actions) != 1:
-            logfire.error("Actions was not an expected payload", event=body)
-            return
-
-        selected_option = actions[0].get("selected_option")
-        if selected_option is None:
-            logfire.error("No selected option in feedback rating action", event=body)
-            return
-
-        value = selected_option.get("value")
-        if value is None:
-            logfire.error("No value in selected option", event=body)
-            return
-
-        parts = value.split("|")
-        if len(parts) != 4:
-            logfire.error("Unexpected value format in feedback rating", value=value)
-            return
-
-        agent_message_ts, channel, user, rating = parts
-
-        await respond(
-            response_type="ephemeral",
-            text="",
-            replace_original=True,
-            delete_original=True,
-        )
-
-        logfire.info(
-            "Agent feedback rating received",
-            agent_message_ts=agent_message_ts,
-            channel=channel,
-            user=user,
-            rating=rating,
-        )
-
-        user_info = await fetch_user_info(client=self._app.client, user_id=user)
-
-        is_external = user_is_external(self._bot_info, user_info=user_info)
-
-        await insert_event(
-            pool=self._pool,
-            event=AgentFeedbackRatingEvent(
-                message_ts=agent_message_ts,
-                channel=channel,
-                rating=int(rating) if rating else None,
-                user=user,
-                subtype=AgentFeedbackRatingSubtype.external
-                if is_external
-                else AgentFeedbackRatingSubtype.internal,
-            ).model_dump(),
-        )
-
-        await self._hctx.trigger.put(True)

--- a/tiger_agent/slack/constants.py
+++ b/tiger_agent/slack/constants.py
@@ -9,7 +9,6 @@ AGENT_FEEDBACK_RECEIVED_SLACK_CHANNEL = os.environ.get(
 
 CONFIRM_PROACTIVE_PROMPT = "confirm_proactive_prompt"
 REJECT_PROACTIVE_PROMPT = "reject_proactive_prompt"
-AGENT_FEEDBACK_RATING = "agent_feedback_rating"
 
 NEW_SALESFORCE_CASE_WORKFLOW_FORM_SUBMIT = "new_salesforce_case_workflow_form_submit"
 NEW_SALESFORCE_CASE_WORKFLOW_FORM_CANCEL = "new_salesforce_case_workflow_form_cancel"

--- a/tiger_agent/slack/utils.py
+++ b/tiger_agent/slack/utils.py
@@ -12,6 +12,7 @@ All functions are designed to be resilient, gracefully handling API errors and p
 structured data models for Slack entities.
 """
 
+import json
 import re
 from collections.abc import Sequence
 from typing import Any
@@ -40,7 +41,6 @@ from slack_sdk.web.async_client import (
 
 from tiger_agent.salesforce.types import FileAttachment, ServiceRecord
 from tiger_agent.slack.constants import (
-    AGENT_FEEDBACK_RATING,
     CONFIRM_PROACTIVE_PROMPT,
     FEEDBACK_FORM_SUBMIT,
     FEEDBACK_FORM_TRIGGER,
@@ -54,7 +54,6 @@ from tiger_agent.slack.types import (
     BotInfo,
     ChannelInfo,
     SlackFile,
-    SlackMessage,
     SlackMessageEvent,
     SlackUrlParts,
     TeamInfo,
@@ -674,79 +673,6 @@ async def send_proactive_prompt(
     )
 
 
-async def send_feedback_rating_prompt(
-    client: AsyncWebClient, agent_message: SlackMessage
-):
-    agent_message_ts = agent_message.ts
-    channel = agent_message.channel_id
-    user = agent_message.to_user_id
-
-    def get_encoded_value(rating: int) -> str:
-        return f"{agent_message_ts}|{channel}|{user}|{rating}"
-
-    await client.chat_postEphemeral(
-        channel=channel,
-        user=user,
-        thread_ts=agent_message_ts,
-        text=f"Hey <@{user}>, how would you rate the helpfulness of my response? ",
-        blocks=[
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"Hey{get_handle_link(user)}, how would you rate the helpfulness of my response?",
-                },
-            },
-            {
-                "type": "actions",
-                "elements": [
-                    {
-                        "type": "radio_buttons",
-                        "action_id": AGENT_FEEDBACK_RATING,
-                        "options": [
-                            {
-                                "text": {
-                                    "type": "plain_text",
-                                    "text": "1 - Not helpful at all",
-                                },
-                                "value": get_encoded_value(1),
-                            },
-                            {
-                                "text": {
-                                    "type": "plain_text",
-                                    "text": "2 - Slightly helpful",
-                                },
-                                "value": get_encoded_value(2),
-                            },
-                            {
-                                "text": {
-                                    "type": "plain_text",
-                                    "text": "3 - Somewhat helpful",
-                                },
-                                "value": get_encoded_value(3),
-                            },
-                            {
-                                "text": {
-                                    "type": "plain_text",
-                                    "text": "4 - Mostly helpful",
-                                },
-                                "value": get_encoded_value(4),
-                            },
-                            {
-                                "text": {
-                                    "type": "plain_text",
-                                    "text": "5 - Very helpful",
-                                },
-                                "value": get_encoded_value(5),
-                            },
-                        ],
-                    }
-                ],
-            },
-        ],
-    )
-
-
 async def handle_proactive_prompt(
     ack: AsyncAck, body: dict[str, Any], respond: AsyncRespond, bot_info: BotInfo
 ) -> int | None:
@@ -836,15 +762,53 @@ async def send_new_case_and_feedback_button(
     return resp.data.get("ts")
 
 
+async def send_feedback_button(
+    client: AsyncWebClient, channel: str, thread_ts: str | None = None
+) -> str | None:
+    resp = await client.chat_postMessage(
+        channel=channel,
+        text="Open a new support case",
+        thread_ts=thread_ts,
+        blocks=[
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "Let me know how I did and how I can do better!",
+                },
+            },
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "action_id": FEEDBACK_FORM_TRIGGER,
+                        "style": "primary",
+                        "text": {"type": "plain_text", "text": "Submit Feedback"},
+                        "value": json.dumps({"thread_ts": thread_ts}),
+                    },
+                ],
+            },
+        ],
+    )
+    assert isinstance(resp.data, dict)
+    return resp.data.get("ts")
+
+
 async def send_feedback_form(
-    client: AsyncWebClient, trigger_id: str, channel: str | None = None
+    client: AsyncWebClient,
+    trigger_id: str,
+    channel: str | None = None,
+    thread_ts: str | None = None,
 ):
     await client.views_open(
         trigger_id=trigger_id,
         view={
             "type": "modal",
             "callback_id": FEEDBACK_FORM_SUBMIT,
-            "private_metadata": channel or "",
+            "private_metadata": json.dumps(
+                {"channel": channel, "thread_ts": thread_ts}
+            ),
             "title": {"type": "plain_text", "text": "Submit Feedback/Request"},
             "submit": {"type": "plain_text", "text": "Submit"},
             "close": {"type": "plain_text", "text": "Cancel"},

--- a/tiger_agent/slack/utils.py
+++ b/tiger_agent/slack/utils.py
@@ -836,7 +836,7 @@ async def send_feedback_form(
                     "optional": True,
                     "label": {
                         "type": "plain_text",
-                        "text": "Rating for Slack case management integration",
+                        "text": "Rating (Optional)",
                     },
                     "element": {
                         "type": "static_select",

--- a/tiger_agent/slack/utils.py
+++ b/tiger_agent/slack/utils.py
@@ -836,7 +836,7 @@ async def send_feedback_form(
                     "optional": True,
                     "label": {
                         "type": "plain_text",
-                        "text": "Rating (Optional)",
+                        "text": "Rating",
                     },
                     "element": {
                         "type": "static_select",

--- a/tiger_agent/tasks/handlers.py
+++ b/tiger_agent/tasks/handlers.py
@@ -64,7 +64,7 @@ from tiger_agent.slack.utils import (
     get_channel_link,
     get_handle_link,
     post_response,
-    send_feedback_rating_prompt,
+    send_feedback_button,
     set_status,
     stream_response_to_mention,
     user_is_external,
@@ -284,15 +284,19 @@ class SalesforceAssignmentChangedHandler(TaskHandler):
                     extra={"permalink": permalink},
                 )
 
-            if message_to_link_to.to_user_id:
-
-                async def _delayed_feedback(client, message):
-                    await asyncio.sleep(10)
-                    await send_feedback_rating_prompt(client, message)
-
-                asyncio.create_task(
-                    _delayed_feedback(hctx.app.client, message_to_link_to)
+            async def _delayed_feedback(client, channel, message_ts):
+                await asyncio.sleep(10)
+                await send_feedback_button(
+                    client=client, channel=channel, thread_ts=message_ts
                 )
+
+            asyncio.create_task(
+                _delayed_feedback(
+                    hctx.app.client,
+                    channel=message_to_link_to.channel_id,
+                    message_ts=message_to_link_to.ts,
+                )
+            )
 
 
 class SalesforceCreateCaseHandler(TaskHandler):


### PR DESCRIPTION
## What
This replaces the ephemeral form message:
<img width="545" height="236" alt="image" src="https://github.com/user-attachments/assets/6560fd08-0fb4-47fb-af81-83f4a44ab194" />

with the modal feedback input (added in this [PR](https://github.com/timescale/tiger-agents-for-work/pull/187)).

## Why
So that there is a means of supplying a description + rating. This creates cohesion between feedback mechanism from customer and support engineer.


## Demo
<img width="1090" height="673" alt="2026-05-06 14 18 11" src="https://github.com/user-attachments/assets/337a3727-5985-4534-a7a4-9f76136df94b" />
