### PR TITLE
[AGE-483] Include EmailMessages in FeedItem events

### DIFF
--- a/tiger_agent/db/utils.py
+++ b/tiger_agent/db/utils.py
@@ -407,17 +407,6 @@ async def filter_new_feed_items(
     if not feed_items:
         return []
 
-    # first, filter to only feed items whose ParentId has a matching case_id
-    # in the salesforce_case_thread table (i.e. cases we are actively tracking)
-    parent_ids = list({item.ParentId for item in feed_items if item.ParentId})
-    async with pool.connection() as con:
-        result = await con.execute(
-            "SELECT DISTINCT case_id FROM agent.salesforce_case_thread WHERE case_id = ANY(%s)",
-            (parent_ids,),
-        )
-        tracked_case_ids = {row[0] for row in await result.fetchall()}
-
-    feed_items = [item for item in feed_items if item.ParentId in tracked_case_ids]
     if not feed_items:
         return []
 

--- a/tiger_agent/salesforce/case_feed_item_poller.py
+++ b/tiger_agent/salesforce/case_feed_item_poller.py
@@ -20,7 +20,10 @@ from simple_salesforce.api import Salesforce
 
 from tiger_agent.db.utils import filter_new_feed_items
 from tiger_agent.salesforce.types import SalesforceFeedItem
-from tiger_agent.salesforce.utils import get_recent_case_feed_items
+from tiger_agent.salesforce.utils import (
+    get_recent_case_email_messages,
+    get_recent_case_feed_items,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +44,19 @@ class SalesforceCaseFeedItemPoller:
         self._handler = handler
         self._poll_interval_seconds = poll_interval_seconds
         self._last_poll: datetime | None = None
+        self._bot_sf_user_id: str | None = None
+
+    def _get_bot_sf_user_id(self) -> str | None:
+        """Fetch and cache the Salesforce user ID of the integration user."""
+        if self._bot_sf_user_id is None:
+            try:
+                result = self._salesforce_client.restful(
+                    "chatter/users/me", method="GET"
+                )
+                self._bot_sf_user_id = result.get("id")
+            except Exception:
+                logfire.exception("Failed to fetch bot Salesforce user ID")
+        return self._bot_sf_user_id
 
     async def _poll(self) -> None:
         # TODO: can improve the fallback by doing a query on the last feed item event in the db
@@ -55,6 +71,12 @@ class SalesforceCaseFeedItemPoller:
             types=["TextPost", "ContentPost"],
             public_only=True,
             created_after=since_str,
+        ) + get_recent_case_email_messages(
+            salesforce_client=self._salesforce_client,
+            created_after=since_str,
+            # the agent will create EmailMessages when syncing Slack messages
+            # so we do not want to create an infinite loop!
+            exclude_creator_id=self._get_bot_sf_user_id(),
         )
 
         # filter out feed items that have already been handled

--- a/tiger_agent/salesforce/utils.py
+++ b/tiger_agent/salesforce/utils.py
@@ -400,6 +400,45 @@ def get_recent_case_feed_items(
         return []
 
 
+def get_recent_case_email_messages(
+    salesforce_client: Salesforce,
+    created_after: str | None = None,
+    incoming_only: bool = False,
+    exclude_creator_id: str | None = None,
+) -> list[SalesforceFeedItem]:
+    """Fetch recent EmailMessages on Cases and normalize them into SalesforceFeedItem shape."""
+    try:
+        conditions = ["ParentId != null"]
+        if created_after is not None:
+            conditions.append(f"CreatedDate > {created_after}")
+        if incoming_only:
+            conditions.append("Incoming = true")
+        if exclude_creator_id is not None:
+            conditions.append(f"CreatedById != '{exclude_creator_id}'")
+        where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+        result = salesforce_client.query(
+            f"SELECT Id, ParentId, TextBody, Subject, CreatedDate, CreatedById,"
+            f" FromName, FromAddress, Incoming"
+            f" FROM EmailMessage{where}"
+            f" ORDER BY CreatedDate DESC"
+        )
+        return [
+            SalesforceFeedItem(
+                Id=r["Id"],
+                ParentId=r.get("ParentId"),
+                Body=r.get("TextBody") or r.get("Subject"),
+                Type="EmailMessage",
+                CreatedDate=r.get("CreatedDate"),
+                CreatedById=r.get("CreatedById"),
+                CreatedBy={"Name": r.get("FromName"), "Email": r.get("FromAddress")},
+            )
+            for r in result.get("records", [])
+        ]
+    except Exception:
+        logfire.exception("Failed to fetch recent case email messages")
+        return []
+
+
 def get_feed_attachment_ids(
     salesforce_client: Salesforce,
     feed_item_id: str,

--- a/tiger_agent/tasks/handlers.py
+++ b/tiger_agent/tasks/handlers.py
@@ -71,8 +71,8 @@ from tiger_agent.slack.utils import (
     stream_response_to_mention,
     user_is_external,
 )
-from tiger_agent.tasks.user_defined_rules import evaluate_user_defined_rules
 from tiger_agent.tasks.types import Task
+from tiger_agent.tasks.user_defined_rules import evaluate_user_defined_rules
 from tiger_agent.types import HarnessContext
 
 logger = logging.getLogger(__name__)
@@ -414,9 +414,15 @@ class SalesforceFeedItemHandler(TaskHandler):
     async def handle(self, task: Task) -> None:
         hctx = self._hctx
         event: SalesforceFeedItemEvent = task.event
-        [channel_id, thread_ts] = await get_salesforce_case_thread_thread_id(
+        result = await get_salesforce_case_thread_thread_id(
             hctx.pool, case_id=event.feed_item.ParentId
         )
+
+        if not result:
+            # if the FeedItem's case is not associated with a Slack thread, do nothing
+            return
+
+        [channel_id, thread_ts] = result
 
         markdown_conversion = HTMLSlacker(event.feed_item.Body).get_output().strip()
         body = add_quote_block(markdown_conversion)


### PR DESCRIPTION
## What
This will now grab new `EmailMessages` when creating new `feed_item` events. Also, moves the filtering of Salesforce<->Slack correlated threads out of the Salesforce listener and into the handler.

## Why
To facilitate Salesforce custom event handling. See https://iobeam.slack.com/archives/C09AF06P37B/p1778234274498029?thread_ts=1778213018.353659&cid=C09AF06P37B