### PR TITLE
[AGE-503] include case emails when creating new case notification message

### DIFF
--- a/tiger_agent/agent/utils.py
+++ b/tiger_agent/agent/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -25,7 +24,13 @@ from tiger_agent.logfire.utils import get_tool_calls_for_event
 from tiger_agent.mcp.utils import filter_mcp_servers
 from tiger_agent.salesforce.types import (
     SalesforceBaseEvent,
+    SalesforceEmailMessage,
     UserDefinedRule,
+)
+from tiger_agent.salesforce.utils import (
+    EXT_TO_MIME,
+    download_content_version_url,
+    get_case_email_messages,
 )
 from tiger_agent.slack.types import SlackBaseEvent, SlackFile
 from tiger_agent.slack.utils import (
@@ -36,7 +41,10 @@ from tiger_agent.slack.utils import (
 )
 from tiger_agent.tasks.types import Task
 from tiger_agent.types import HarnessContext
-from tiger_agent.utils import wrap_mcp_servers_with_exception_handling
+from tiger_agent.utils import (
+    pretty_print_models,
+    wrap_mcp_servers_with_exception_handling,
+)
 
 if TYPE_CHECKING:
     from tiger_agent.agent.tiger_agent import TigerAgent
@@ -85,16 +93,20 @@ async def create_agent_and_context(
     extra_ctx: ExtraContextDict = {}
     await agent.augment_context(ctx=ctx, extra_ctx=extra_ctx)
 
-    if not isinstance(event, SalesforceBaseEvent) and event.thread_ts and hctx.bot_info:
+    # for salesforce and slack events, let's grab any conversational elements
+    # and add for extra context.
+    if isinstance(event, SalesforceBaseEvent):
+        case_emails = get_case_email_messages(hctx.salesforce_client, event.case.Id)
+        extra_ctx["case_emails"] = pretty_print_models(case_emails)
+
+    elif event.thread_ts and hctx.bot_info:
         thread_messages = await fetch_thread_messages(
             client=hctx.app.client,
             channel=event.channel,
             thread_ts=event.thread_ts,
         )
 
-        extra_ctx["thread_history"] = json.dumps(
-            [m.model_dump() for m in thread_messages]
-        )
+        extra_ctx["thread_history"] = pretty_print_models(thread_messages)
 
     system_prompt = await agent.make_system_prompt(ctx=ctx, extra_ctx=extra_ctx)
     user_prompt = await agent.make_user_prompt(ctx=ctx, extra_ctx=extra_ctx)
@@ -105,6 +117,21 @@ async def create_agent_and_context(
         file: SlackFile,
     ) -> BinaryContent | str | None:
         return await download_slack_hosted_file(file=file)
+
+    def _get_case_emails(case_id: str) -> list[SalesforceEmailMessage]:
+        res = get_case_email_messages(hctx.salesforce_client, case_id=case_id)
+        return res
+
+    def _download_salesforce_hosted_file(
+        url: str, filename: str
+    ) -> BinaryContent | str:
+        ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+        media_type = EXT_TO_MIME.get(ext, "application/octet-stream")
+        try:
+            content = download_content_version_url(hctx.salesforce_client, url)
+            return BinaryContent(data=content, media_type=media_type)
+        except Exception as e:
+            return f"Failed to download file: {e}"
 
     _event_type_by_name: dict[str, type] = {
         cls.__name__: cls for cls in EVENT_TYPE_REGISTRY
@@ -170,6 +197,26 @@ async def create_agent_and_context(
             name="download_slack_hosted_file",
             description="This will download a file associated with a Slack message and return its contents. Note: only images, text, or PDFs are supported.",
         ),
+        Tool(
+            _download_salesforce_hosted_file,
+            takes_ctx=False,
+            name="download_salesforce_hosted_file",
+            description=(
+                "Download a Salesforce-hosted file by its relative URL and filename. "
+                "Use this for inline images in EmailMessage HtmlBody (e.g. <img src='/sfc/servlet.shepherd/version/download/<id>' alt='filename.png'>). "
+                "Pass the src as url and the alt attribute value as filename."
+            ),
+        ),
+        Tool(
+            _get_case_emails,
+            takes_ctx=False,
+            name="fetch_salesforce_case_emails",
+            description=(
+                "Fetch email messages on a Salesforce case by case ID. "
+                'Use this when the user asks to get, show, or retrieve emails on a case (e.g. "get me case emails on <case_id>", "show emails for case <case_id>"). '
+                "Prefer this tool over any MCP server tool for fetching case emails."
+            ),
+        ),
         *(
             [
                 Tool(
@@ -232,63 +279,7 @@ async def create_agent_and_context(
         output_type=AgentSalesforceResponse
         if isinstance(event, SalesforceBaseEvent)
         else str,
-        tools=[
-            Tool(
-                _download_slack_hosted_file,
-                takes_ctx=False,
-                name="download_slack_hosted_file",
-                description="This will download a file associated with a Slack message and return its contents. Note: only images, text, or PDFs are supported.",
-            ),
-            *(
-                [
-                    Tool(
-                        _list_user_defined_rules,
-                        takes_ctx=False,
-                        name="list_user_defined_rules",
-                        description=(
-                            "List all user-defined rules owned by the current user. "
-                            'Use when the user asks things like "show me my rules", '
-                            '"what rules do I have set up?", or "list my custom rules".'
-                        ),
-                    ),
-                    Tool(
-                        _delete_user_defined_rule,
-                        takes_ctx=False,
-                        name="delete_user_defined_rule",
-                        description=(
-                            "Delete a user-defined rule by its ID. Only rules owned by the current user "
-                            "can be deleted. Returns True if deleted, False if not found. Use when the user asks things like "
-                            '"delete rule 3", "remove my rule with ID 7", or "turn off rule 12".'
-                        ),
-                    ),
-                    Tool(
-                        _create_user_defined_rule,
-                        takes_ctx=False,
-                        name="create_user_defined_rule",
-                        description=(
-                            "Call this when the user wants to be notified, alerted, or asks to create a rule or automation. "
-                            "Creates a persistent rule that triggers a custom action when a matching event occurs. "
-                            "Infer all parameters from the user's request.\n"
-                            f"event_type must be one of:\n{event_type_options}\n"
-                            "criteria_examples are optional but improve matching accuracy."
-                        ),
-                    ),
-                    Tool(
-                        _get_tool_calls_for_event,
-                        takes_ctx=False,
-                        name="get_tool_calls_for_event",
-                        description=(
-                            "Retrieve all tool calls made by the agent in response to the current Slack event. "
-                            "Returns a JSON list of tool calls with their names, arguments, and responses. "
-                            'Use when the user asks things like "what tools did you call?", '
-                            '"what did you look up?", or "show me what you did last time".'
-                        ),
-                    ),
-                ]
-                if isinstance(event, SlackBaseEvent)
-                else []
-            ),
-        ],
+        tools=tools,
         toolsets=toolsets,
         model_settings={"extra_headers": {"anthropic-beta": "context-1m-2025-08-07"}}
         if (isinstance(agent.model, str) and agent.model.startswith("anthropic:"))

--- a/tiger_agent/agent/utils.py
+++ b/tiger_agent/agent/utils.py
@@ -24,13 +24,11 @@ from tiger_agent.logfire.utils import get_tool_calls_for_event
 from tiger_agent.mcp.utils import filter_mcp_servers
 from tiger_agent.salesforce.types import (
     SalesforceBaseEvent,
-    SalesforceEmailMessage,
     UserDefinedRule,
 )
 from tiger_agent.salesforce.utils import (
     EXT_TO_MIME,
     download_content_version_url,
-    get_case_email_messages,
 )
 from tiger_agent.slack.types import SlackBaseEvent, SlackFile
 from tiger_agent.slack.utils import (
@@ -93,13 +91,7 @@ async def create_agent_and_context(
     extra_ctx: ExtraContextDict = {}
     await agent.augment_context(ctx=ctx, extra_ctx=extra_ctx)
 
-    # for salesforce and slack events, let's grab any conversational elements
-    # and add for extra context.
-    if isinstance(event, SalesforceBaseEvent):
-        case_emails = get_case_email_messages(hctx.salesforce_client, event.case.Id)
-        extra_ctx["case_emails"] = pretty_print_models(case_emails)
-
-    elif event.thread_ts and hctx.bot_info:
+    if not isinstance(event, SalesforceBaseEvent) and event.thread_ts and hctx.bot_info:
         thread_messages = await fetch_thread_messages(
             client=hctx.app.client,
             channel=event.channel,
@@ -117,10 +109,6 @@ async def create_agent_and_context(
         file: SlackFile,
     ) -> BinaryContent | str | None:
         return await download_slack_hosted_file(file=file)
-
-    def _get_case_emails(case_id: str) -> list[SalesforceEmailMessage]:
-        res = get_case_email_messages(hctx.salesforce_client, case_id=case_id)
-        return res
 
     def _download_salesforce_hosted_file(
         url: str, filename: str
@@ -205,16 +193,6 @@ async def create_agent_and_context(
                 "Download a Salesforce-hosted file by its relative URL and filename. "
                 "Use this for inline images in EmailMessage HtmlBody (e.g. <img src='/sfc/servlet.shepherd/version/download/<id>' alt='filename.png'>). "
                 "Pass the src as url and the alt attribute value as filename."
-            ),
-        ),
-        Tool(
-            _get_case_emails,
-            takes_ctx=False,
-            name="fetch_salesforce_case_emails",
-            description=(
-                "Fetch email messages on a Salesforce case by case ID. "
-                'Use this when the user asks to get, show, or retrieve emails on a case (e.g. "get me case emails on <case_id>", "show emails for case <case_id>"). '
-                "Prefer this tool over any MCP server tool for fetching case emails."
             ),
         ),
         *(

--- a/tiger_agent/prompts/user_prompt.md
+++ b/tiger_agent/prompts/user_prompt.md
@@ -34,15 +34,9 @@ A new Salesforce support case has been received.
 
 {% endif %}
 
-{% if case_emails %}
-
 ## Case Emails
 
-The following is the email history in the Salesforce case. If an email has an attachment or an inline image, download the attachment for full context.
-
-{{ case_emails }}
-
-{% endif %}
+Call `get_case_details` with `case_id_or_number` set to `{{ mention.case.Id }}` and `query_salesforce_directly` set to `true` to retrieve the full email thread. If an email has an attached or inline image, download that image for fuller context.
 
 {% elif mention.type in ["app_mention", "message"] %}
 

--- a/tiger_agent/prompts/user_prompt.md
+++ b/tiger_agent/prompts/user_prompt.md
@@ -34,6 +34,16 @@ A new Salesforce support case has been received.
 
 {% endif %}
 
+{% if case_emails %}
+
+## Case Emails
+
+The following is the email history in the Salesforce case. If an email has an attachment or an inline image, download the attachment for full context.
+
+{{ case_emails }}
+
+{% endif %}
+
 {% elif mention.type in ["app_mention", "message"] %}
 
 ## Event Type

--- a/tiger_agent/salesforce/case_feed_item_poller.py
+++ b/tiger_agent/salesforce/case_feed_item_poller.py
@@ -21,8 +21,8 @@ from simple_salesforce.api import Salesforce
 from tiger_agent.db.utils import filter_new_feed_items
 from tiger_agent.salesforce.types import SalesforceFeedItem
 from tiger_agent.salesforce.utils import (
-    get_recent_case_email_messages,
-    get_recent_case_feed_items,
+    get_case_email_messages,
+    get_case_feed_items,
 )
 
 logger = logging.getLogger(__name__)
@@ -66,12 +66,12 @@ class SalesforceCaseFeedItemPoller:
         self._last_poll = datetime.now(UTC)
         since_str = since.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-        case_feed_items = get_recent_case_feed_items(
+        case_feed_items = get_case_feed_items(
             salesforce_client=self._salesforce_client,
             types=["TextPost", "ContentPost"],
             public_only=True,
             created_after=since_str,
-        ) + get_recent_case_email_messages(
+        ) + get_case_email_messages(
             salesforce_client=self._salesforce_client,
             created_after=since_str,
             # the agent will create EmailMessages when syncing Slack messages

--- a/tiger_agent/salesforce/types.py
+++ b/tiger_agent/salesforce/types.py
@@ -106,6 +106,15 @@ class SalesforceFeedItem(BaseModel):
     CreatedBy: SalesforceFeedItemCreatedBy | None = None
 
 
+class SalesforceEmailMessage(SalesforceFeedItem):
+    """Pydantic model for a Salesforce EmailMessage record."""
+
+    Subject: str | None = None
+    HasAttachment: bool | None = None
+    Type: str | None = "EmailMessage"
+    HtmlBody: str | None = None
+
+
 # at present, we are using these to synchronize
 # comments made on cases with a Slack thread
 # that is linked to the case

--- a/tiger_agent/salesforce/utils.py
+++ b/tiger_agent/salesforce/utils.py
@@ -25,6 +25,7 @@ from tiger_agent.salesforce.types import (
     ContentVersion,
     EmailAttachment,
     FileAttachment,
+    SalesforceEmailMessage,
     SalesforceFeedItem,
     ServiceRecord,
 )
@@ -372,8 +373,9 @@ def add_case_email_comment(
         )
 
 
-def get_recent_case_feed_items(
+def get_case_feed_items(
     salesforce_client: Salesforce,
+    case_id: str | None = None,
     created_after: str | None = None,
     types: list[str] | None = None,
     public_only: bool = False,
@@ -387,6 +389,8 @@ def get_recent_case_feed_items(
             conditions.append(f"Type IN ({type_list})")
         if public_only:
             conditions.append("Visibility = 'AllUsers'")
+        if case_id:
+            conditions.append(f"Parent.Id = {case_id}")
         where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
         result = salesforce_client.query(
             f"SELECT Id, ParentId, Body, Type, CreatedDate, CreatedById,"
@@ -400,12 +404,13 @@ def get_recent_case_feed_items(
         return []
 
 
-def get_recent_case_email_messages(
+def get_case_email_messages(
     salesforce_client: Salesforce,
+    case_id: str | None = None,
     created_after: str | None = None,
     incoming_only: bool = False,
     exclude_creator_id: str | None = None,
-) -> list[SalesforceFeedItem]:
+) -> list[SalesforceEmailMessage]:
     """Fetch recent EmailMessages on Cases and normalize them into SalesforceFeedItem shape."""
     try:
         conditions = ["ParentId != null"]
@@ -415,21 +420,25 @@ def get_recent_case_email_messages(
             conditions.append("Incoming = true")
         if exclude_creator_id is not None:
             conditions.append(f"CreatedById != '{exclude_creator_id}'")
+        if case_id:
+            conditions.append(f"Parent.Id = '{case_id}'")
         where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
         result = salesforce_client.query(
             f"SELECT Id, ParentId, TextBody, Subject, CreatedDate, CreatedById,"
-            f" FromName, FromAddress, Incoming"
+            f" FromName, FromAddress, Incoming, HasAttachment, HtmlBody"
             f" FROM EmailMessage{where}"
             f" ORDER BY CreatedDate DESC"
         )
         return [
-            SalesforceFeedItem(
+            SalesforceEmailMessage(
                 Id=r["Id"],
                 ParentId=r.get("ParentId"),
                 Body=r.get("TextBody") or r.get("Subject"),
-                Type="EmailMessage",
                 CreatedDate=r.get("CreatedDate"),
                 CreatedById=r.get("CreatedById"),
+                HtmlBody=r.get("HtmlBody"),
+                Subject=r.get("Subject"),
+                HasAttachment=r.get("HasAttachment"),
                 CreatedBy={"Name": r.get("FromName"), "Email": r.get("FromAddress")},
             )
             for r in result.get("records", [])
@@ -448,6 +457,32 @@ def get_feed_attachment_ids(
         f"SELECT Id FROM FeedAttachment WHERE FeedEntityId = '{feed_item_id}'"
     )
     return [r["Id"] for r in result.get("records", [])]
+
+
+def download_content_version_url(
+    salesforce_client: Salesforce, content_version_url: str
+) -> bytes:
+    # Shepherd URLs (/sfc/servlet.shepherd/version/download/{id}) require browser
+    # cookie auth. Rewrite them to the REST API VersionData endpoint which accepts
+    # Bearer auth, same as the VersionData path returned by SOQL queries.
+    shepherd_match = re.search(
+        r"/sfc/servlet\.shepherd/version/download/([A-Za-z0-9]+)",
+        content_version_url,
+    )
+    if shepherd_match:
+        version_id = shepherd_match.group(1)
+        content_version_url = f"/services/data/v{salesforce_client.sf_version}/sobjects/ContentVersion/{version_id}/VersionData"
+
+    url = f"https://{salesforce_client.sf_instance}{content_version_url}"
+    response = salesforce_client.session.get(
+        url,
+        headers={
+            "Authorization": f"Bearer {salesforce_client.session_id}",
+            "Accept": "*/*",
+        },
+    )
+    response.raise_for_status()
+    return response.content
 
 
 @logfire.instrument("download_feed_attachment {feed_attachment_id=}")
@@ -503,7 +538,6 @@ def download_feed_attachment(
                 )
                 return None
 
-        url = f"https://{salesforce_client.sf_instance}{content_version.VersionData}"
         name = content_version.Title or feed_attachment_id
         extension = content_version.FileExtension
         if extension:
@@ -511,18 +545,14 @@ def download_feed_attachment(
         content_type = EXT_TO_MIME.get(
             (extension or "").lower(), "application/octet-stream"
         )
-        response = salesforce_client.session.get(
-            url,
-            headers={
-                "Authorization": f"Bearer {salesforce_client.session_id}",
-                "Accept": "*/*",
-            },
+        body = download_content_version_url(
+            salesforce_client=salesforce_client,
+            content_version_url=content_version.VersionData,
         )
-        response.raise_for_status()
 
         return FileAttachment(
             name=name,
-            body=response.content,
+            body=body,
             content_type=content_type,
         )
     except Exception:

--- a/tiger_agent/utils.py
+++ b/tiger_agent/utils.py
@@ -199,3 +199,15 @@ def get_harness_ctx(
         max_age_minutes=max_age_minutes,
         invisibility_minutes=invisibility_minutes,
     )
+
+
+def _pretty_print_model(model: BaseModel) -> str:
+    return "\n".join(
+        f"{k}: {v}" for k, v in model.model_dump().items() if v is not None
+    )
+
+
+def pretty_print_models(models: list[BaseModel]) -> str:
+    return "\n\n".join(
+        f"--- {i} ---\n{_pretty_print_model(m)}" for i, m in enumerate(models, 1)
+    )

--- a/tiger_agent/utils.py
+++ b/tiger_agent/utils.py
@@ -201,13 +201,27 @@ def get_harness_ctx(
     )
 
 
-def _pretty_print_model(model: BaseModel) -> str:
-    return "\n".join(
-        f"{k}: {v}" for k, v in model.model_dump().items() if v is not None
-    )
+def _to_yaml(value: Any, indent: int = 0) -> str:
+    pad = "  " * indent
+    if isinstance(value, dict):
+        lines = []
+        for k, v in value.items():
+            if v is None:
+                continue
+            rendered = _to_yaml(v, indent + 1)
+            if "\n" in rendered:
+                lines.append(f"{pad}{k}:\n{rendered}")
+            else:
+                lines.append(f"{pad}{k}: {rendered}")
+        return "\n".join(lines)
+    if isinstance(value, list):
+        items = [f"{pad}- {_to_yaml(v, indent + 1).lstrip()}" for v in value if v is not None]
+        return "\n".join(items)
+    return str(value)
 
 
 def pretty_print_models(models: list[BaseModel]) -> str:
-    return "\n\n".join(
-        f"--- {i} ---\n{_pretty_print_model(m)}" for i, m in enumerate(models, 1)
-    )
+    parts = []
+    for model in models:
+        parts.append(f"---\n{_to_yaml(model.model_dump())}")
+    return "\n\n".join(parts)


### PR DESCRIPTION
## What
This adds message context (e.g. case emails + attachments) into the user prompt when handling new Salesforce case events. Feedback was given for this [case notification](https://iobeam.slack.com/archives/C0AK9P2V1LK/p1779444026369359?thread_ts=1779444026.138519&cid=C0AK9P2V1LK) that the user already provided the screenshot that eon asked the customer for.

Prior to this, case notifications are based solely on the actual case metadata (e.g. description, owner, submitter), rather than including existing emails. When eon receives the event to create a new notification in `#eon-support-cases`, there should really only be a single email (e.g. the email message that triggered the new case).

Attachments in these customer emails can appear as inline images, or attachments.


## What else
* add some utility functions to pretty print pydantic models and use this to format Slack messages (which we are already adding to the context via the `extra_context["thread_history"]` value
* fix duplication/dead code when creating the array of tools for the agent

## Related PRs
This updates the MCP so that it returns emails in Html format if available (so that we have access to inline images) and also adds an override parameter to query salesforce directly.
https://github.com/timescale/tiger-salesforce-mcp-server/pull/27


## Follow up
Going to refactor the agent/context creation code.