### PR TITLE
[AGE-506] send ephemeral message after feedback received

### DIFF
--- a/tiger_agent/listeners/slack.py
+++ b/tiger_agent/listeners/slack.py
@@ -361,6 +361,22 @@ class SlackListener(Listener):
             user=user_id,
         )
 
+        await self._hctx.app.client.chat_postEphemeral(
+            channel=channel,
+            user=user_id,
+            text="Thank you for submitting feedback!",
+            blocks=[
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"*Feedback Received*\nScore: `{rating}`\nDescription: ```{description}```\n\nThank you for your feedback!",
+                    },
+                },
+            ],
+            thread_ts=message_ts,
+        )
+
     async def _handle_proactive_prompt(
         self, ack: AsyncAck, body: dict[str, Any], respond: AsyncRespond
     ):


### PR DESCRIPTION
## What
Sends a message to the person that submitted feedback

<img width="654" height="612" alt="image" src="https://github.com/user-attachments/assets/5cd36c4c-393a-4093-a894-0cce9bbac912" />

## Why
So people can see what threads they have already submitted feedback for.