### PR TITLE
[AGE-507] Add feedback request reminders

### DIFF
--- a/tiger_agent/agent/types.py
+++ b/tiger_agent/agent/types.py
@@ -5,7 +5,6 @@ from pydantic import BaseModel, Field
 
 from tiger_agent.mcp.types import MCPDict
 from tiger_agent.salesforce.types import (
-    AgentFeedbackRatingEvent,
     SalesforceAssignmentChangedEvent,
     SalesforceCaseStatusChangedEvent,
     SalesforceCreateNewCaseEvent,
@@ -13,6 +12,8 @@ from tiger_agent.salesforce.types import (
     UserDefinedRuleMatch,
 )
 from tiger_agent.slack.types import (
+    AgentFeedbackRatingEvent,
+    AgentFeedbackRequestReminderEvent,
     BotInfo,
     SlackAppMentionEvent,
     SlackMessageEvent,
@@ -48,6 +49,7 @@ class AgentResponseContext(BaseModel):
         | SalesforceFeedItemEvent
         | SalesforceCaseStatusChangedEvent
         | AgentFeedbackRatingEvent
+        | AgentFeedbackRequestReminderEvent
         | UserDefinedRuleMatch
     )
     bot: BotInfo

--- a/tiger_agent/app.py
+++ b/tiger_agent/app.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from tiger_agent.agent.tiger_agent import TigerAgent
 from tiger_agent.listeners.harness import ListenerHarness
 from tiger_agent.salesforce.types import (
-    AgentFeedbackRatingEvent,
     SalesforceAssignmentChangedEvent,
     SalesforceCaseStatusChangedEvent,
     SalesforceCreateNewCaseEvent,
@@ -13,12 +12,15 @@ from tiger_agent.salesforce.types import (
     UserDefinedRuleMatch,
 )
 from tiger_agent.slack.types import (
+    AgentFeedbackRatingEvent,
+    AgentFeedbackRequestReminderEvent,
     SlackAppMentionEvent,
     SlackMessageEvent,
     SlackSalesforceCaseThreadMessageEvent,
 )
 from tiger_agent.tasks.handlers import (
     AgentFeedbackRatingHandler,
+    AgentFeedbackRequestReminderHandler,
     SalesforceAssignmentChangedHandler,
     SalesforceCaseStatusChangedHandler,
     SalesforceCreateCaseHandler,
@@ -127,8 +129,10 @@ class TigerApp:
             AgentFeedbackRatingEvent, AgentFeedbackRatingHandler(hctx=hctx)
         )
         processor.register(
-            UserDefinedRuleMatch, UserDefinedRuleMatchHandler(hctx=hctx)
+            AgentFeedbackRequestReminderEvent,
+            AgentFeedbackRequestReminderHandler(hctx=hctx),
         )
+        processor.register(UserDefinedRuleMatch, UserDefinedRuleMatchHandler(hctx=hctx))
 
         self._hctx = hctx
         self._listener_harness = ListenerHarness(hctx=hctx, task_processor=processor)

--- a/tiger_agent/db/utils.py
+++ b/tiger_agent/db/utils.py
@@ -110,7 +110,7 @@ async def insert_event(
 
     Args:
         event: Raw Slack/Salesforce event payload as dictionary
-        timeout: How far in the future that the event should be handled. Defaults to 0 seconds
+        vt: Manually set the visibility timestamp -- if None, will be now()
     """
     async with (
         pool.connection() as con,

--- a/tiger_agent/db/utils.py
+++ b/tiger_agent/db/utils.py
@@ -477,7 +477,7 @@ async def get_matching_user_defined_rules(
 
 
 async def get_feedback_request_reminder(
-    pool: AsyncConnectionPool, user_id: str, vt: datetime | None = None
+    pool: AsyncConnectionPool, user_id: str, vt: datetime
 ) -> Event | None:
     async with pool.connection() as con, con.cursor(row_factory=dict_row) as cur:
         await cur.execute(
@@ -486,9 +486,9 @@ async def get_feedback_request_reminder(
                    WHERE
                         event->>'type' = %s
                         AND event->>'user' = %s
-                        AND ((%s is NULL) or (vt = %s))
+                        AND vt = %s
                         """,
-            [AGENT_FEEDBACK_REQUEST_REMINDER, user_id, vt, vt],
+            [AGENT_FEEDBACK_REQUEST_REMINDER, user_id, vt],
         )
         row = await cur.fetchone()
 

--- a/tiger_agent/db/utils.py
+++ b/tiger_agent/db/utils.py
@@ -1,6 +1,6 @@
 import logging
-from datetime import timedelta
-from typing import Any
+from datetime import datetime, timedelta
+from typing import Any, Literal
 
 import logfire
 from psycopg import AsyncConnection
@@ -14,6 +14,11 @@ from tiger_agent.salesforce.types import (
     SalesforceBaseEvent,
     SalesforceFeedItem,
     UserDefinedRule,
+)
+from tiger_agent.slack.types import (
+    AGENT_FEEDBACK_REQUEST_REMINDER,
+    AgentFeedbackRequestReminderEvent,
+    FeedbackReminderThread,
 )
 from tiger_agent.tasks.types import Task as Event
 
@@ -93,7 +98,11 @@ async def user_is_admin(pool: AsyncConnectionPool, user_id: str) -> bool:
 
 
 @logfire.instrument("insert_event", extract_args=False)
-async def insert_event(pool: AsyncConnectionPool, event: dict[str, Any]) -> None:
+async def insert_event(
+    pool: AsyncConnectionPool,
+    event: dict[str, Any],
+    vt: datetime | None = None,
+) -> None:
     """Insert a Slack/Salesforce event into the database work queue.
 
     Uses the agent.insert_event() database function to store the event
@@ -101,13 +110,17 @@ async def insert_event(pool: AsyncConnectionPool, event: dict[str, Any]) -> None
 
     Args:
         event: Raw Slack/Salesforce event payload as dictionary
+        timeout: How far in the future that the event should be handled. Defaults to 0 seconds
     """
     async with (
         pool.connection() as con,
         con.transaction() as _,
         con.cursor() as cur,
     ):
-        await cur.execute("select agent.insert_event(%s)", (Jsonb(event),))
+        await cur.execute(
+            "select agent.insert_event(%s, %s::timestamptz)",
+            [Jsonb(event), vt],
+        )
 
 
 @logfire.instrument("insert_handled_event", extract_args=False)
@@ -461,6 +474,68 @@ async def get_matching_user_defined_rules(
                 (event_type,),
             )
         return [UserDefinedRule(**row) for row in await cur.fetchall()]
+
+
+async def get_feedback_request_reminder(
+    pool: AsyncConnectionPool, user_id: str, vt: datetime | None = None
+) -> Event | None:
+    async with pool.connection() as con, con.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            """SELECT *
+                   FROM agent.event
+                   WHERE
+                        event->>'type' = %s
+                        AND event->>'user' = %s
+                        AND ((%s is NULL) or (vt = %s))
+                        """,
+            [AGENT_FEEDBACK_REQUEST_REMINDER, user_id, vt, vt],
+        )
+        row = await cur.fetchone()
+
+        if row:
+            return Event(**row)
+        return None
+
+
+async def upsert_feedback_request_reminder(
+    pool: AsyncConnectionPool,
+    user_id: str,
+    thread: FeedbackReminderThread,
+    action: Literal["add", "remove"],
+    reminder_datetime: datetime,
+) -> None:
+
+    existing = await get_feedback_request_reminder(
+        pool=pool, user_id=user_id, vt=reminder_datetime
+    )
+
+    new_event: AgentFeedbackRequestReminderEvent | None = None
+
+    if existing:
+        assert isinstance(existing.event, AgentFeedbackRequestReminderEvent)
+        await delete_event(pool=pool, event=existing)
+
+        if action == "add":
+            new_event = existing.event.model_copy(
+                update={"threads": existing.event.threads + [thread]}
+            )
+        elif action == "remove":
+            remaining = [
+                t
+                for t in existing.event.threads
+                if (t.channel != thread.channel and t.message_ts != thread.message_ts)
+            ]
+
+            if not remaining:
+                return
+            new_event = existing.event.model_copy(update={"threads": remaining})
+    else:
+        new_event = AgentFeedbackRequestReminderEvent(user=user_id, threads=[thread])
+
+    if new_event:
+        await insert_event(
+            pool=pool, event=new_event.model_dump(), vt=reminder_datetime
+        )
 
 
 @logfire.instrument("insert_user_defined_rule", extract_args=False)

--- a/tiger_agent/db/utils.py
+++ b/tiger_agent/db/utils.py
@@ -504,7 +504,8 @@ async def upsert_feedback_request_reminder(
     action: Literal["add", "remove"],
     reminder_datetime: datetime,
 ) -> None:
-
+    # agent.event has no unique constraint on (user, type, vt), so we use
+    # delete-then-insert as the upsert strategy.
     existing = await get_feedback_request_reminder(
         pool=pool, user_id=user_id, vt=reminder_datetime
     )
@@ -513,6 +514,7 @@ async def upsert_feedback_request_reminder(
 
     if existing:
         assert isinstance(existing.event, AgentFeedbackRequestReminderEvent)
+        # Always delete first — we re-insert below with the updated thread list.
         await delete_event(pool=pool, event=existing)
 
         if action == "add":
@@ -527,6 +529,7 @@ async def upsert_feedback_request_reminder(
             ]
 
             if not remaining:
+                # No threads left — deletion above is sufficient.
                 return
             new_event = existing.event.model_copy(update={"threads": remaining})
     else:

--- a/tiger_agent/events.py
+++ b/tiger_agent/events.py
@@ -7,13 +7,13 @@ Each class in EVENT_TYPE_REGISTRY must have:
 """
 
 from tiger_agent.salesforce.types import (
-    AgentFeedbackRatingEvent,
     SalesforceAssignmentChangedEvent,
     SalesforceCaseStatusChangedEvent,
     SalesforceCreateNewCaseEvent,
     SalesforceFeedItemEvent,
 )
 from tiger_agent.slack.types import (
+    AgentFeedbackRatingEvent,
     SlackAppMentionEvent,
     SlackMessageEvent,
     SlackSalesforceCaseThreadMessageEvent,

--- a/tiger_agent/listeners/slack.py
+++ b/tiger_agent/listeners/slack.py
@@ -14,11 +14,10 @@ from tiger_agent.db.utils import (
     get_salesforce_case_thread_case_id,
     insert_event,
     insert_handled_event,
+    upsert_feedback_request_reminder,
 )
 from tiger_agent.listeners import Listener
 from tiger_agent.salesforce.types import (
-    AgentFeedbackRatingEvent,
-    AgentFeedbackRatingSubtype,
     SalesforceCreateNewCaseEvent,
 )
 from tiger_agent.salesforce.utils import (
@@ -38,13 +37,17 @@ from tiger_agent.slack.constants import (
     SLACK_APP_TOKEN,
 )
 from tiger_agent.slack.types import (
+    AgentFeedbackRatingEvent,
+    AgentFeedbackRatingSubtype,
     BotInfo,
+    FeedbackReminderThread,
     SlackCommand,
     SlackSalesforceCaseThreadMessageEvent,
     UserInfo,
 )
 from tiger_agent.slack.utils import (
     fetch_bot_info,
+    fetch_end_of_day_for_user,
     fetch_team_info,
     fetch_user_info,
     handle_new_salesforce_case_workflow_form_cancel,
@@ -375,6 +378,18 @@ class SlackListener(Listener):
                 },
             ],
             thread_ts=message_ts,
+        )
+
+        users_end_of_day = await fetch_end_of_day_for_user(
+            client=self._hctx.app.client, user_id=user_id
+        )
+
+        await upsert_feedback_request_reminder(
+            pool=self._hctx.pool,
+            user_id=user_id,
+            action="remove",
+            reminder_datetime=users_end_of_day,
+            thread=FeedbackReminderThread(channel=channel, message_ts=message_ts, label=""),
         )
 
     async def _handle_proactive_prompt(

--- a/tiger_agent/migrations/idempotent/001-event.sql
+++ b/tiger_agent/migrations/idempotent/001-event.sql
@@ -2,19 +2,20 @@
 
 -----------------------------------------------------------------------
 -- agent.insert_event
-create or replace function agent.insert_event(_event jsonb) returns void
+create or replace function agent.insert_event(_event jsonb, vt timestamptz = NULL) returns void
 as $func$
     insert into agent.event
     ( event_ts
     , event
+    , vt
     )
     select
       coalesce(agent.to_timestamptz((_event->>'event_ts')::numeric), now())
     , _event
+    , coalesce(vt, now())
     ;
 $func$ language sql volatile security invoker
 ;
-
 
 -----------------------------------------------------------------------
 -- agent.claim_event

--- a/tiger_agent/salesforce/types.py
+++ b/tiger_agent/salesforce/types.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from enum import StrEnum
 from typing import ClassVar
 
 from pydantic import BaseModel, field_validator
@@ -140,26 +139,6 @@ class SalesforceCaseStatusChangedEvent(SalesforceBaseEvent):
     case: CaseData
     slack_thread_ts: str | None = None
     slack_channel_id: str | None = None
-
-
-class AgentFeedbackRatingSubtype(StrEnum):
-    internal = "internal"
-    external = "external"
-
-
-class AgentFeedbackRatingEvent(BaseModel):
-    type: str = "agent_feedback_rating"
-    subtype: AgentFeedbackRatingSubtype = AgentFeedbackRatingSubtype.internal
-    event_description: ClassVar[str] = (
-        "A user submitted a feedback rating via the in-app feedback form"
-    )
-
-    # the agent message that was rated
-    message_ts: str | None = None
-    channel: str
-    rating: int | None = None
-    description: str | None = None
-    user: str | None = None
 
 
 @dataclass

--- a/tiger_agent/slack/types.py
+++ b/tiger_agent/slack/types.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any, ClassVar
 
 from pydantic import BaseModel, model_validator
@@ -236,7 +237,9 @@ class SlackAppMentionEvent(SlackBaseEvent):
     """Pydantic model for Slack app_mention events."""
 
     type: str = "app_mention"
-    event_description: ClassVar[str] = "A user directly @mentioned the bot in a Slack channel"
+    event_description: ClassVar[str] = (
+        "A user directly @mentioned the bot in a Slack channel"
+    )
 
 
 class SlackMessageEvent(SlackBaseEvent):
@@ -244,7 +247,9 @@ class SlackMessageEvent(SlackBaseEvent):
 
     type: str = "message"
     subtype: str | None = None
-    event_description: ClassVar[str] = "A message posted in a Slack channel the bot is monitoring"
+    event_description: ClassVar[str] = (
+        "A message posted in a Slack channel the bot is monitoring"
+    )
 
 
 class SlackSalesforceCaseThreadMessageEvent(SlackBaseEvent):
@@ -258,6 +263,43 @@ class SlackSalesforceCaseThreadMessageEvent(SlackBaseEvent):
     model_config = {"extra": "allow"}
 
     type: str = "slack_salesforce_case_thread_message"
-    event_description: ClassVar[str] = "A Slack message posted in a thread linked to a Salesforce case"
+    event_description: ClassVar[str] = (
+        "A Slack message posted in a thread linked to a Salesforce case"
+    )
 
     salesforce_case_id: str
+
+
+class AgentFeedbackRatingSubtype(StrEnum):
+    internal = "internal"
+    external = "external"
+
+
+class AgentFeedbackRatingEvent(BaseModel):
+    type: str = "agent_feedback_rating"
+    subtype: AgentFeedbackRatingSubtype = AgentFeedbackRatingSubtype.internal
+    event_description: ClassVar[str] = (
+        "A user submitted a feedback rating via the in-app feedback form"
+    )
+
+    # the agent message that was rated
+    message_ts: str | None = None
+    channel: str
+    rating: int | None = None
+    description: str | None = None
+    user: str | None = None
+
+
+class FeedbackReminderThread(BaseModel):
+    channel: str
+    message_ts: str
+    label: str
+
+
+AGENT_FEEDBACK_REQUEST_REMINDER = "agent_feedback_request_reminder"
+
+
+class AgentFeedbackRequestReminderEvent(BaseModel):
+    type: str = AGENT_FEEDBACK_REQUEST_REMINDER
+    user: str
+    threads: list[FeedbackReminderThread]

--- a/tiger_agent/slack/utils.py
+++ b/tiger_agent/slack/utils.py
@@ -15,11 +15,13 @@ structured data models for Slack entities.
 import json
 import re
 from collections.abc import Sequence
+from datetime import datetime, timedelta
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 import httpx
 import logfire
+import pytz
 from pydantic_ai.messages import (
     AgentStreamEvent,
     BaseToolCallPart,
@@ -175,6 +177,36 @@ async def fetch_user_info(client: AsyncWebClient, user_id: str) -> UserInfo | No
     except Exception:
         logfire.exception("Failed to fetch user info", user_id=user_id)
         return None
+
+
+async def fetch_end_of_day_for_user(client: AsyncWebClient, user_id: str) -> datetime:
+    """Gets the end of day for a given user (e.g. 5pm their timezone). If we are beyond their end of day,
+    return the next day at that time.
+
+    Args:
+        client (AsyncWebClient): _description_
+        user_id (str): The user's Slack ID
+
+    Raises:
+        Exception: Cannot find the user in the Slack API
+
+    Returns:
+        datetime: the end of day object
+    """
+    user_info = await fetch_user_info(client, user_id=user_id)
+
+    if not user_info:
+        raise Exception(f"Could not find user {user_id}")
+    now = datetime.now()
+    end_of_day = now.replace(hour=17, minute=0, second=0, microsecond=0)
+
+    # if we are past the end of day, set the end of day to be tomorrow
+    if now > end_of_day:
+        end_of_day + timedelta(days=1)
+
+    localized = pytz.timezone(user_info.tz).localize(end_of_day)
+
+    return localized
 
 
 @logfire.instrument(

--- a/tiger_agent/tasks/handlers.py
+++ b/tiger_agent/tasks/handlers.py
@@ -363,7 +363,7 @@ class AgentFeedbackRequestReminderHandler(TaskHandler):
             client=hctx.app.client,
             channel=event.user,
             thread_ts=None,
-            text=f"Hey, just a reminder to leave feedback on the following threads:\n{thread_links}",
+            text=f"Hey! Thanks for all your support today. When you get a chance, we'd love to hear your thoughts on these conversations:\n{thread_links}",
         )
 
 

--- a/tiger_agent/tasks/handlers.py
+++ b/tiger_agent/tasks/handlers.py
@@ -20,6 +20,7 @@ from tiger_agent.db.utils import (
     add_salesforce_case_thread,
     get_salesforce_account_id_for_channel,
     get_salesforce_case_thread_thread_id,
+    upsert_feedback_request_reminder,
     usage_limit_reached,
     user_ignored,
 )
@@ -33,8 +34,6 @@ from tiger_agent.salesforce.constants import (
     SALESFORCE_SLACK_THREAD_FIELD,
 )
 from tiger_agent.salesforce.types import (
-    AgentFeedbackRatingEvent,
-    AgentFeedbackRatingSubtype,
     SalesforceAssignmentChangedEvent,
     SalesforceBaseEvent,
     SalesforceCaseStatusChangedEvent,
@@ -53,6 +52,10 @@ from tiger_agent.salesforce.utils import (
 )
 from tiger_agent.slack.constants import AGENT_FEEDBACK_RECEIVED_SLACK_CHANNEL
 from tiger_agent.slack.types import (
+    AgentFeedbackRatingEvent,
+    AgentFeedbackRatingSubtype,
+    AgentFeedbackRequestReminderEvent,
+    FeedbackReminderThread,
     SlackAppMentionEvent,
     SlackMessage,
     SlackMessageEvent,
@@ -61,6 +64,7 @@ from tiger_agent.slack.types import (
 from tiger_agent.slack.utils import (
     add_quote_block,
     add_reaction,
+    fetch_end_of_day_for_user,
     fetch_user_info,
     get_a_href_link_to_user_profile,
     get_channel_link,
@@ -295,6 +299,23 @@ class SalesforceAssignmentChangedHandler(TaskHandler):
                     extra={"permalink": permalink},
                 )
 
+            if case_owner_user_id:
+                users_end_of_day = await fetch_end_of_day_for_user(
+                    client=hctx.app.client, user_id=case_owner_user_id
+                )
+
+                await upsert_feedback_request_reminder(
+                    pool=hctx.pool,
+                    user_id=case_owner_user_id,
+                    thread=FeedbackReminderThread(
+                        channel=message_to_link_to.channel_id,
+                        message_ts=message_to_link_to.ts,
+                        label=event.case.CaseNumber,
+                    ),
+                    action="add",
+                    reminder_datetime=users_end_of_day,
+                )
+
             async def _delayed_feedback(client, channel, message_ts):
                 await asyncio.sleep(10)
                 await send_feedback_button(
@@ -308,6 +329,42 @@ class SalesforceAssignmentChangedHandler(TaskHandler):
                     message_ts=message_to_link_to.ts,
                 )
             )
+
+
+class AgentFeedbackRequestReminderHandler(TaskHandler):
+    """
+    When the agent supplies feedback, we have a mechanism that will remind the recipient
+    to leave feedback. At this time, the only scenario that this will happen is when the agent
+    gives a suggested response for a new Salesforce case. When the new case event occurs,
+    we enqueue a AgentFeedbackRequestReminderEvent with a future vt -- this effectively
+    schedules the reminder for the future (e.g. at the end of the support engineer's day)
+    """
+
+    @logfire.instrument(
+        "AgentFeedbackRequestReminderHandler.handle", extract_args=False
+    )
+    async def handle(self, task: Task) -> None:
+        hctx = self._hctx
+        event: AgentFeedbackRequestReminderEvent = task.event
+
+        permalink_results = await asyncio.gather(
+            *[
+                hctx.app.client.chat_getPermalink(
+                    channel=t.channel, message_ts=t.message_ts
+                )
+                for t in event.threads
+            ]
+        )
+        thread_links = "\n".join(
+            f"• <{result.data.get('permalink')}|{t.label}>"
+            for t, result in zip(event.threads, permalink_results, strict=True)
+        )
+        await post_response(
+            client=hctx.app.client,
+            channel=event.user,
+            thread_ts=None,
+            text=f"Hey, just a reminder to leave feedback on the following threads:\n{thread_links}",
+        )
 
 
 class SalesforceCreateCaseHandler(TaskHandler):

--- a/tiger_agent/tasks/types.py
+++ b/tiger_agent/tasks/types.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from pydantic import BaseModel
 
 from tiger_agent.salesforce.types import (
-    AgentFeedbackRatingEvent,
     SalesforceAssignmentChangedEvent,
     SalesforceCaseStatusChangedEvent,
     SalesforceCreateNewCaseEvent,
@@ -11,6 +10,8 @@ from tiger_agent.salesforce.types import (
     UserDefinedRuleMatch,
 )
 from tiger_agent.slack.types import (
+    AgentFeedbackRatingEvent,
+    AgentFeedbackRequestReminderEvent,
     SlackAppMentionEvent,
     SlackMessageEvent,
     SlackSalesforceCaseThreadMessageEvent,
@@ -46,5 +47,6 @@ class Task(BaseModel):
         | SalesforceFeedItemEvent
         | SalesforceCaseStatusChangedEvent
         | AgentFeedbackRatingEvent
+        | AgentFeedbackRequestReminderEvent
         | UserDefinedRuleMatch
     )


### PR DESCRIPTION
## What
This adds auto-reminders for requesting feedback on threads where the agent has interacted. At present, this is only relevant to the auto-suggestions on new Salesforce cases. This will send a DM directly to the assigned support engineers with a list of all threads that need feedback submitted.

## How
This adds a new `AgentFeedbackRequestReminderEvent` event definition, which contains a sundry array of `threads` (each one representing a thread that the agent can receive feedback for). This event is popped into the `agent.event` table with a `vt` (visibility timestamp) that is set to the EOD to the relevant user (e.g. the support engineer assigned the case). 

As new cases are assigned to the user, the one event will be updated, with new cases being added to the already created `AgentFeedbackRequestReminderEvent` event. When a user submits feedback, the relevant thread will be removed from the `AgentFeedbackRequestReminderEvent` -- and if there are no threads left to be reviewed, the entire event will be deleted from `agent.event`.


## Example reminder
<img width="394" height="160" alt="image" src="https://github.com/user-attachments/assets/676defea-a8a2-4541-9388-e425ae5657dc" />

Note: the case names are all the same on that screenshot due to testing environment