### PR TITLE
Token efficiency: tunable prompt caching, tool result compaction, gated 1M context header

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "slack-bolt>=1.26.0",
     "tzdata>=2025.2",
     "websockets>=15.0.1",
+    "toons>=0.7.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ version = {attr = "tiger_agent.__version__"}
 
 [dependency-groups]
 dev = [
+    "pytest>=9.0.3",
     "ruff>=0.13.1",
 ]
 
@@ -70,3 +71,4 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.ruff.lint.per-file-ignores]
 "db/tests/*" = ["E501", "SIM117", "W291", "ARG001"]
+"tests/*" = ["ARG001"]

--- a/tests/test_build_model_settings.py
+++ b/tests/test_build_model_settings.py
@@ -1,0 +1,53 @@
+"""Tests for build_model_settings in tiger_agent.agent.utils."""
+
+from pydantic_ai.models.anthropic import AnthropicModel
+
+from tiger_agent.agent.utils import build_model_settings
+
+CACHE_KEYS = {
+    "anthropic_cache_tool_definitions",
+    "anthropic_cache_instructions",
+    "anthropic_cache_messages",
+}
+BETA_HEADER = {"anthropic-beta": "context-1m-2025-08-07"}
+
+
+def test_default_ttl_on_modern_anthropic_model():
+    settings = build_model_settings("anthropic:claude-sonnet-4-6", "5m")
+    assert settings == dict.fromkeys(CACHE_KEYS, "5m")
+
+
+def test_one_hour_ttl():
+    settings = build_model_settings("anthropic:claude-sonnet-4-6", "1h")
+    assert settings == dict.fromkeys(CACHE_KEYS, "1h")
+
+
+def test_cache_disabled_on_modern_model_yields_none():
+    assert build_model_settings("anthropic:claude-sonnet-4-6", None) is None
+
+
+def test_cache_disabled_on_sonnet_45_keeps_beta_header():
+    settings = build_model_settings("anthropic:claude-sonnet-4-5", None)
+    assert settings == {"extra_headers": BETA_HEADER}
+
+
+def test_sonnet_4_gets_header_and_cache():
+    settings = build_model_settings("anthropic:claude-sonnet-4-20250514", "5m")
+    assert settings["extra_headers"] == BETA_HEADER
+    assert all(settings[k] == "5m" for k in CACHE_KEYS)
+
+
+def test_non_anthropic_model_yields_none():
+    assert build_model_settings("openai:gpt-4o", "5m") is None
+
+
+def test_no_model_yields_none():
+    assert build_model_settings(None, "5m") is None
+
+
+def test_anthropic_model_instance(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    model = AnthropicModel("claude-sonnet-4-5")
+    settings = build_model_settings(model, "5m")
+    assert settings["extra_headers"] == BETA_HEADER
+    assert all(settings[k] == "5m" for k in CACHE_KEYS)

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -2,6 +2,8 @@
 
 import json
 
+import toons
+
 from tiger_agent.compression import (
     MAX_COMPACT_RATIO,
     MIN_COMPRESSABLE_CHARS,
@@ -9,13 +11,20 @@ from tiger_agent.compression import (
 )
 
 
-def make_items(n: int = 20, pad: int = 400) -> list[dict]:
-    """Build n similarly-shaped dicts with constant and varying fields."""
+def make_flat(n: int = 80) -> list[dict]:
+    """Flat, uniform rows — the shape TOON compacts into a column table."""
+    return [
+        {"id": i, "title": f"Issue {i}", "status": "open", "score": i * 7 % 100}
+        for i in range(n)
+    ]
+
+
+def make_nested(n: int = 20, pad: int = 400) -> list[dict]:
+    """Rows with a nested object — TOON can't tabulate these, so they stay JSON."""
     return [
         {
             "id": i,
             "title": f"Issue {i}",
-            "status": "open",
             "team": {"id": "T1", "name": "Platform"},
             "description": "x" * pad,
         }
@@ -24,7 +33,7 @@ def make_items(n: int = 20, pad: int = 400) -> list[dict]:
 
 
 def test_small_result_passes_through():
-    payload = json.dumps(make_items(n=5, pad=0))
+    payload = json.dumps(make_flat(n=5))
     assert len(payload) < MIN_COMPRESSABLE_CHARS
     assert compress_tool_result(payload) is payload
 
@@ -39,76 +48,45 @@ def test_non_json_non_collection_passes_through():
     assert compress_tool_result(None) is None
 
 
-def test_large_json_array_is_compacted():
-    payload = json.dumps(make_items())
+def test_large_flat_array_is_compacted():
+    payload = json.dumps(make_flat())
     compacted = compress_tool_result(payload)
     assert isinstance(compacted, str)
     assert compacted is not payload
     assert len(compacted) < len(payload) * MAX_COMPACT_RATIO
-    # Constant fields are factored out once.
-    assert compacted.count('"open"') == 1
-    assert compacted.count("Platform") == 1
 
 
-def test_all_items_preserved():
-    items = make_items()
+def test_compaction_is_lossless():
+    items = make_flat()
     compacted = compress_tool_result(json.dumps(items))
-    for item in items:
-        assert json.dumps(item["title"]) in compacted
+    # TOON encoding round-trips back to the original items — no data dropped.
+    assert toons.loads(compacted) == items
 
 
 def test_python_list_input_is_compacted():
-    items = make_items()
+    items = make_flat()
     compacted = compress_tool_result(items)
     assert isinstance(compacted, str)
-    assert len(compacted) < len(json.dumps(items))
+    assert toons.loads(compacted) == items
 
 
-def test_dict_envelope_keeps_scalar_fields():
-    payload = json.dumps({"issues": make_items(), "next_cursor": "abc123"})
-    compacted = compress_tool_result(payload)
-    assert compacted is not payload
+def test_dict_envelope_is_compacted_and_lossless():
+    payload_obj = {"issues": make_flat(), "next_cursor": "abc123", "has_more": True}
+    compacted = compress_tool_result(json.dumps(payload_obj))
+    assert isinstance(compacted, str)
     assert "next_cursor" in compacted
     assert "abc123" in compacted
-    assert "'issues'" in compacted
+    assert toons.loads(compacted) == payload_obj
 
 
-def test_missing_keys_marked_absent():
-    items = make_items()
-    del items[3]["title"]
-    compacted = compress_tool_result(json.dumps(items))
-    assert "<absent>" in compacted
-
-
-def test_pipe_in_value_stays_quoted():
-    # The column separator is " | ", so a value containing pipes could be
-    # mistaken for column boundaries. Cells are JSON-encoded, so the value
-    # stays wrapped in quotes and a row remains recoverable by tracking quotes
-    # rather than naively splitting on the separator.
-    items = make_items()
-    items[5]["title"] = "this | has | pipes"
-    compacted = compress_tool_result(json.dumps(items))
-    assert '"this | has | pipes"' in compacted
-
-
-def test_irregular_array_passes_through():
-    payload = json.dumps(["just a string", *make_items()])
-    assert compress_tool_result(payload) is payload
-
-
-def test_few_items_pass_through():
-    payload = json.dumps(make_items(n=3, pad=3000))
+def test_nested_array_not_smaller_passes_through():
+    # Nested objects block TOON's column table, so the encoding is ~JSON-sized
+    # and the ratio gate keeps the original JSON.
+    payload = json.dumps(make_nested())
     assert len(payload) > MIN_COMPRESSABLE_CHARS
     assert compress_tool_result(payload) is payload
 
 
-def test_insufficient_savings_keeps_original():
-    # One short key with long unique values: key dedup saves almost nothing.
-    items = [{"a": f"{i}" * 2000} for i in range(5)]
-    payload = json.dumps(items)
-    assert compress_tool_result(payload) is payload
-
-
 def test_unserializable_input_falls_back_to_original():
-    bad = {("tuple", "key"): make_items()}
+    bad = {("tuple", "key"): make_flat()}
     assert compress_tool_result(bad) is bad

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -1,0 +1,103 @@
+"""Tests for tiger_agent.compression."""
+
+import json
+
+from tiger_agent.compression import (
+    MAX_COMPACT_RATIO,
+    MIN_COMPRESSABLE_CHARS,
+    compress_tool_result,
+)
+
+
+def make_items(n: int = 20, pad: int = 400) -> list[dict]:
+    """Build n similarly-shaped dicts with constant and varying fields."""
+    return [
+        {
+            "id": i,
+            "title": f"Issue {i}",
+            "status": "open",
+            "team": {"id": "T1", "name": "Platform"},
+            "description": "x" * pad,
+        }
+        for i in range(n)
+    ]
+
+
+def test_small_result_passes_through():
+    payload = json.dumps(make_items(n=5, pad=0))
+    assert len(payload) < MIN_COMPRESSABLE_CHARS
+    assert compress_tool_result(payload) is payload
+
+
+def test_non_json_string_passes_through():
+    text = "plain text result " * 500
+    assert compress_tool_result(text) is text
+
+
+def test_non_json_non_collection_passes_through():
+    assert compress_tool_result(42) == 42
+    assert compress_tool_result(None) is None
+
+
+def test_large_json_array_is_compacted():
+    payload = json.dumps(make_items())
+    compacted = compress_tool_result(payload)
+    assert isinstance(compacted, str)
+    assert compacted is not payload
+    assert len(compacted) < len(payload) * MAX_COMPACT_RATIO
+    # Constant fields are factored out once.
+    assert compacted.count('"open"') == 1
+    assert compacted.count("Platform") == 1
+
+
+def test_all_items_preserved():
+    items = make_items()
+    compacted = compress_tool_result(json.dumps(items))
+    for item in items:
+        assert json.dumps(item["title"]) in compacted
+
+
+def test_python_list_input_is_compacted():
+    items = make_items()
+    compacted = compress_tool_result(items)
+    assert isinstance(compacted, str)
+    assert len(compacted) < len(json.dumps(items))
+
+
+def test_dict_envelope_keeps_scalar_fields():
+    payload = json.dumps({"issues": make_items(), "next_cursor": "abc123"})
+    compacted = compress_tool_result(payload)
+    assert compacted is not payload
+    assert "next_cursor" in compacted
+    assert "abc123" in compacted
+    assert "'issues'" in compacted
+
+
+def test_missing_keys_marked_absent():
+    items = make_items()
+    del items[3]["title"]
+    compacted = compress_tool_result(json.dumps(items))
+    assert "<absent>" in compacted
+
+
+def test_irregular_array_passes_through():
+    payload = json.dumps(["just a string", *make_items()])
+    assert compress_tool_result(payload) is payload
+
+
+def test_few_items_pass_through():
+    payload = json.dumps(make_items(n=3, pad=3000))
+    assert len(payload) > MIN_COMPRESSABLE_CHARS
+    assert compress_tool_result(payload) is payload
+
+
+def test_insufficient_savings_keeps_original():
+    # One short key with long unique values: key dedup saves almost nothing.
+    items = [{"a": f"{i}" * 2000} for i in range(5)]
+    payload = json.dumps(items)
+    assert compress_tool_result(payload) is payload
+
+
+def test_unserializable_input_falls_back_to_original():
+    bad = {("tuple", "key"): make_items()}
+    assert compress_tool_result(bad) is bad

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -80,6 +80,17 @@ def test_missing_keys_marked_absent():
     assert "<absent>" in compacted
 
 
+def test_pipe_in_value_stays_quoted():
+    # The column separator is " | ", so a value containing pipes could be
+    # mistaken for column boundaries. Cells are JSON-encoded, so the value
+    # stays wrapped in quotes and a row remains recoverable by tracking quotes
+    # rather than naively splitting on the separator.
+    items = make_items()
+    items[5]["title"] = "this | has | pipes"
+    compacted = compress_tool_result(json.dumps(items))
+    assert '"this | has | pipes"' in compacted
+
+
 def test_irregular_array_passes_through():
     payload = json.dumps(["just a string", *make_items()])
     assert compress_tool_result(payload) is payload

--- a/tests/test_wrapped_process_tool_call.py
+++ b/tests/test_wrapped_process_tool_call.py
@@ -7,8 +7,8 @@ from tiger_agent.utils import create_wrapped_process_tool_call
 
 LARGE_PAYLOAD = json.dumps(
     [
-        {"id": i, "status": "open", "description": "x" * 400, "title": f"Issue {i}"}
-        for i in range(20)
+        {"id": i, "status": "open", "score": i * 7 % 100, "title": f"Issue {i}"}
+        for i in range(80)
     ]
 )
 

--- a/tests/test_wrapped_process_tool_call.py
+++ b/tests/test_wrapped_process_tool_call.py
@@ -1,0 +1,84 @@
+"""Tests for create_wrapped_process_tool_call in tiger_agent.utils."""
+
+import asyncio
+import json
+
+from tiger_agent.utils import create_wrapped_process_tool_call
+
+LARGE_PAYLOAD = json.dumps(
+    [
+        {"id": i, "status": "open", "description": "x" * 400, "title": f"Issue {i}"}
+        for i in range(20)
+    ]
+)
+
+
+def call_tool_returning(result):
+    async def call_tool(name, tool_args, metadata):
+        return result
+
+    return call_tool
+
+
+def run(wrapped, call_tool, name="some_tool", tool_args=None):
+    return asyncio.run(wrapped(None, call_tool, name, tool_args or {}))
+
+
+def test_passthrough_without_compression():
+    wrapped = create_wrapped_process_tool_call(None)
+    result = run(wrapped, call_tool_returning(LARGE_PAYLOAD))
+    assert result is LARGE_PAYLOAD
+
+
+def test_large_result_compacted_when_enabled():
+    wrapped = create_wrapped_process_tool_call(None, compress_results=True)
+    result = run(wrapped, call_tool_returning(LARGE_PAYLOAD))
+    assert result is not LARGE_PAYLOAD
+    assert len(result) < len(LARGE_PAYLOAD)
+
+
+def test_small_result_untouched_when_enabled():
+    wrapped = create_wrapped_process_tool_call(None, compress_results=True)
+    result = run(wrapped, call_tool_returning("small"))
+    assert result == "small"
+
+
+def test_existing_hook_runs_and_result_is_compacted():
+    async def existing(ctx, call_tool, name, tool_args):
+        return LARGE_PAYLOAD
+
+    async def call_tool(name, tool_args, metadata):
+        raise AssertionError("call_tool should not be reached when a hook exists")
+
+    wrapped = create_wrapped_process_tool_call(existing, compress_results=True)
+    result = run(wrapped, call_tool)
+    assert result is not LARGE_PAYLOAD
+    assert len(result) < len(LARGE_PAYLOAD)
+
+
+def test_standard_exception_is_caught():
+    # Regression: `ex.message or ex` raised AttributeError on standard
+    # exceptions, letting the original exception escape the wrapper.
+    async def call_tool(name, tool_args, metadata):
+        raise ValueError("kapow")
+
+    wrapped = create_wrapped_process_tool_call(None)
+    result = run(wrapped, call_tool)
+    assert result == "Tool call failed, could not retrieve information. Error: kapow"
+
+
+def test_message_bearing_exception_uses_message_attr():
+    class McpStyleError(Exception):
+        def __init__(self):
+            super().__init__("str form")
+            self.message = "mcp-style message attr"
+
+    async def call_tool(name, tool_args, metadata):
+        raise McpStyleError()
+
+    wrapped = create_wrapped_process_tool_call(None)
+    result = run(wrapped, call_tool)
+    assert result == (
+        "Tool call failed, could not retrieve information. "
+        "Error: mcp-style message attr"
+    )

--- a/tiger_agent/agent/tiger_agent.py
+++ b/tiger_agent/agent/tiger_agent.py
@@ -61,8 +61,9 @@ class TigerAgent:
             prompt, and message history on Anthropic models ("5m" or "1h", defaults
             to "5m"). Pass None to disable prompt caching.
         compress_tool_results: Compact oversized JSON tool results before they
-            reach the model by rendering arrays of similar objects as tables with
-            constant fields factored out (defaults to True). No items are dropped;
+            reach the model by re-encoding them as TOON, which factors per-row
+            object keys out of uniform arrays (defaults to True). Encoding is
+            lossless and only applied when meaningfully smaller than the original;
             see tiger_agent.compression for thresholds.
 
     Raises:

--- a/tiger_agent/agent/tiger_agent.py
+++ b/tiger_agent/agent/tiger_agent.py
@@ -60,6 +60,10 @@ class TigerAgent:
         anthropic_cache_ttl: Prompt cache TTL applied to tool definitions, system
             prompt, and message history on Anthropic models ("5m" or "1h", defaults
             to "5m"). Pass None to disable prompt caching.
+        compress_tool_results: Compact oversized JSON tool results before they
+            reach the model by rendering arrays of similar objects as tables with
+            constant fields factored out (defaults to True). No items are dropped;
+            see tiger_agent.compression for thresholds.
 
     Raises:
         ValueError: If jinja_env is provided but not async-enabled, or if both jinja_env and prompt_config are provided
@@ -75,6 +79,7 @@ class TigerAgent:
         rate_limit_allowed_requests: int | None = None,
         rate_limit_interval: timedelta = timedelta(minutes=1),
         anthropic_cache_ttl: Literal["5m", "1h"] | None = "5m",
+        compress_tool_results: bool = True,
     ):
         self.bot_info: BotInfo | None = None
         self.model = model
@@ -123,6 +128,7 @@ class TigerAgent:
         self.rate_limit_allowed_requests = rate_limit_allowed_requests
         self.rate_limit_interval = rate_limit_interval
         self.anthropic_cache_ttl = anthropic_cache_ttl
+        self.compress_tool_results = compress_tool_results
 
     async def render_prompts(
         self,

--- a/tiger_agent/agent/tiger_agent.py
+++ b/tiger_agent/agent/tiger_agent.py
@@ -12,7 +12,7 @@ import re
 from collections.abc import Sequence
 from datetime import timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import logfire
 from jinja2 import ChoiceLoader, Environment, FileSystemLoader, PackageLoader
@@ -57,6 +57,9 @@ class TigerAgent:
         max_attempts: Maximum retry attempts for failed tasks (defaults to 3)
         rate_limit_allowed_requests: Maximum requests allowed per interval for rate limiting
         rate_limit_interval: Time interval for rate limiting (defaults to 1 minute)
+        anthropic_cache_ttl: Prompt cache TTL applied to tool definitions, system
+            prompt, and message history on Anthropic models ("5m" or "1h", defaults
+            to "5m"). Pass None to disable prompt caching.
 
     Raises:
         ValueError: If jinja_env is provided but not async-enabled, or if both jinja_env and prompt_config are provided
@@ -71,6 +74,7 @@ class TigerAgent:
         max_attempts: int = 3,
         rate_limit_allowed_requests: int | None = None,
         rate_limit_interval: timedelta = timedelta(minutes=1),
+        anthropic_cache_ttl: Literal["5m", "1h"] | None = "5m",
     ):
         self.bot_info: BotInfo | None = None
         self.model = model
@@ -118,6 +122,7 @@ class TigerAgent:
         self.max_attempts = max_attempts
         self.rate_limit_allowed_requests = rate_limit_allowed_requests
         self.rate_limit_interval = rate_limit_interval
+        self.anthropic_cache_ttl = anthropic_cache_ttl
 
     async def render_prompts(
         self,

--- a/tiger_agent/agent/utils.py
+++ b/tiger_agent/agent/utils.py
@@ -47,6 +47,12 @@ from tiger_agent.utils import (
 if TYPE_CHECKING:
     from tiger_agent.agent.tiger_agent import TigerAgent
 
+# Models that only get the 1M context window via the beta header. Newer models
+# (Sonnet 4.6+, Opus 4.6+) include 1M context at standard pricing and don't
+# need it; on these older models the header bills requests over 200K input
+# tokens at premium long-context rates, so only send it where it does something.
+LONG_CONTEXT_BETA_MODELS = ("claude-sonnet-4-5", "claude-sonnet-4-2025")
+
 
 @dataclass
 class AgentAndContext:
@@ -250,6 +256,32 @@ async def create_agent_and_context(
             )
         )
 
+    is_anthropic = (
+        isinstance(agent.model, str) and agent.model.startswith("anthropic:")
+    ) or isinstance(agent.model, AnthropicModel)
+
+    model_settings: dict[str, Any] | None = None
+    if is_anthropic:
+        model_settings = {}
+        if agent.anthropic_cache_ttl is not None:
+            # Cache tool definitions, system prompt, and message history so
+            # each iteration of the agentic loop re-reads them at ~0.1x input
+            # price instead of full price (5m writes cost 1.25x, so caching
+            # pays for itself after a single read).
+            model_settings.update(
+                anthropic_cache_tool_definitions=agent.anthropic_cache_ttl,
+                anthropic_cache_instructions=agent.anthropic_cache_ttl,
+                anthropic_cache_messages=agent.anthropic_cache_ttl,
+            )
+        model_name = (
+            agent.model if isinstance(agent.model, str) else agent.model.model_name
+        )
+        if any(model in model_name for model in LONG_CONTEXT_BETA_MODELS):
+            model_settings["extra_headers"] = {
+                "anthropic-beta": "context-1m-2025-08-07"
+            }
+        model_settings = model_settings or None
+
     pydantic_agent = Agent(
         model=agent.model,
         deps_type=dict[str, Any],
@@ -259,10 +291,7 @@ async def create_agent_and_context(
         else str,
         tools=tools,
         toolsets=toolsets,
-        model_settings={"extra_headers": {"anthropic-beta": "context-1m-2025-08-07"}}
-        if (isinstance(agent.model, str) and agent.model.startswith("anthropic:"))
-        or isinstance(agent.model, AnthropicModel)
-        else None,
+        model_settings=model_settings,
     )
 
     return AgentAndContext(

--- a/tiger_agent/agent/utils.py
+++ b/tiger_agent/agent/utils.py
@@ -82,7 +82,9 @@ async def create_agent_and_context(
         channel_id=channel_to_respond,
     )
 
-    wrap_mcp_servers_with_exception_handling(mcp_servers=mcp_servers)
+    wrap_mcp_servers_with_exception_handling(
+        mcp_servers=mcp_servers, compress_tool_results=agent.compress_tool_results
+    )
 
     ctx = AgentResponseContext(
         task=task,

--- a/tiger_agent/agent/utils.py
+++ b/tiger_agent/agent/utils.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic_ai import Agent, BinaryContent, Tool
 from pydantic_ai.messages import UserContent
+from pydantic_ai.models import Model
 from pydantic_ai.models.anthropic import AnthropicModel
 
 from tiger_agent.agent.types import (
@@ -52,6 +53,34 @@ if TYPE_CHECKING:
 # need it; on these older models the header bills requests over 200K input
 # tokens at premium long-context rates, so only send it where it does something.
 LONG_CONTEXT_BETA_MODELS = ("claude-sonnet-4-5", "claude-sonnet-4-2025")
+
+
+def build_model_settings(
+    model: Model | str | None,
+    anthropic_cache_ttl: Literal["5m", "1h"] | None,
+) -> dict[str, Any] | None:
+    """Assemble Anthropic-specific model settings (prompt caching, 1M beta header)."""
+    is_anthropic = (
+        isinstance(model, str) and model.startswith("anthropic:")
+    ) or isinstance(model, AnthropicModel)
+    if not is_anthropic:
+        return None
+
+    model_settings: dict[str, Any] = {}
+    if anthropic_cache_ttl is not None:
+        # Cache tool definitions, system prompt, and message history so
+        # each iteration of the agentic loop re-reads them at ~0.1x input
+        # price instead of full price (5m writes cost 1.25x, so caching
+        # pays for itself after a single read).
+        model_settings.update(
+            anthropic_cache_tool_definitions=anthropic_cache_ttl,
+            anthropic_cache_instructions=anthropic_cache_ttl,
+            anthropic_cache_messages=anthropic_cache_ttl,
+        )
+    model_name = model if isinstance(model, str) else model.model_name
+    if any(model in model_name for model in LONG_CONTEXT_BETA_MODELS):
+        model_settings["extra_headers"] = {"anthropic-beta": "context-1m-2025-08-07"}
+    return model_settings or None
 
 
 @dataclass
@@ -258,32 +287,6 @@ async def create_agent_and_context(
             )
         )
 
-    is_anthropic = (
-        isinstance(agent.model, str) and agent.model.startswith("anthropic:")
-    ) or isinstance(agent.model, AnthropicModel)
-
-    model_settings: dict[str, Any] | None = None
-    if is_anthropic:
-        model_settings = {}
-        if agent.anthropic_cache_ttl is not None:
-            # Cache tool definitions, system prompt, and message history so
-            # each iteration of the agentic loop re-reads them at ~0.1x input
-            # price instead of full price (5m writes cost 1.25x, so caching
-            # pays for itself after a single read).
-            model_settings.update(
-                anthropic_cache_tool_definitions=agent.anthropic_cache_ttl,
-                anthropic_cache_instructions=agent.anthropic_cache_ttl,
-                anthropic_cache_messages=agent.anthropic_cache_ttl,
-            )
-        model_name = (
-            agent.model if isinstance(agent.model, str) else agent.model.model_name
-        )
-        if any(model in model_name for model in LONG_CONTEXT_BETA_MODELS):
-            model_settings["extra_headers"] = {
-                "anthropic-beta": "context-1m-2025-08-07"
-            }
-        model_settings = model_settings or None
-
     pydantic_agent = Agent(
         model=agent.model,
         deps_type=dict[str, Any],
@@ -293,7 +296,7 @@ async def create_agent_and_context(
         else str,
         tools=tools,
         toolsets=toolsets,
-        model_settings=model_settings,
+        model_settings=build_model_settings(agent.model, agent.anthropic_cache_ttl),
     )
 
     return AgentAndContext(

--- a/tiger_agent/agent/utils.py
+++ b/tiger_agent/agent/utils.py
@@ -78,7 +78,7 @@ def build_model_settings(
             anthropic_cache_messages=anthropic_cache_ttl,
         )
     model_name = model if isinstance(model, str) else model.model_name
-    if any(model in model_name for model in LONG_CONTEXT_BETA_MODELS):
+    if any(family in model_name for family in LONG_CONTEXT_BETA_MODELS):
         model_settings["extra_headers"] = {"anthropic-beta": "context-1m-2025-08-07"}
     return model_settings or None
 

--- a/tiger_agent/compression.py
+++ b/tiger_agent/compression.py
@@ -1,0 +1,116 @@
+"""Compact oversized MCP tool results before they reach the model.
+
+Large tool results (issue lists, search hits, query results) are dominated by
+JSON arrays of similarly-shaped objects, and most of their bulk is object keys
+repeated per item plus field values shared by every item. Rendering such
+arrays as a table with the constant fields factored out removes that
+redundancy without dropping any items. Results that aren't shaped this way
+(plain text, binary content, irregular JSON) pass through untouched.
+"""
+
+import json
+import logging
+from typing import Any
+
+from pydantic_ai.mcp import ToolResult
+
+logger = logging.getLogger(__name__)
+
+# Results smaller than this pass through untouched; compacting small payloads
+# costs more than it saves.
+MIN_COMPRESSABLE_CHARS = 4_000
+
+# Arrays with fewer items than this stay as JSON; tables only pay off when
+# keys repeat enough times.
+MIN_TABLE_ROWS = 5
+
+# Keep the original unless the compacted form is at least 20% smaller.
+MAX_COMPACT_RATIO = 0.8
+
+
+def compress_tool_result(result: ToolResult) -> ToolResult:
+    """Compact a large JSON tool result; return the original if not applicable."""
+    try:
+        if isinstance(result, str):
+            try:
+                obj = json.loads(result)
+            except ValueError:
+                return result
+            original_len = len(result)
+        elif isinstance(result, (dict, list)):
+            obj = result
+            original_len = len(json.dumps(obj, default=str))
+        else:
+            return result
+
+        if original_len < MIN_COMPRESSABLE_CHARS:
+            return result
+
+        compacted = _compact(obj)
+        if compacted is not None and len(compacted) < original_len * MAX_COMPACT_RATIO:
+            logger.info(
+                "compacted tool result from %d to %d chars",
+                original_len,
+                len(compacted),
+            )
+            return compacted
+    except Exception:
+        logger.exception("tool result compaction failed, returning original")
+    return result
+
+
+def _compact(obj: Any) -> str | None:
+    if isinstance(obj, list):
+        return _tabulate(obj, title="items")
+
+    if isinstance(obj, dict):
+        tables = []
+        remainder = dict(obj)
+        for key, value in obj.items():
+            table = _tabulate(value, title=key) if isinstance(value, list) else None
+            if table is not None:
+                remainder[key] = f"<{len(value)} items, see table '{key}' below>"
+                tables.append(table)
+        if not tables:
+            return None
+        return "\n\n".join([_dumps(remainder), *tables])
+
+    return None
+
+
+def _tabulate(items: list[Any], title: str) -> str | None:
+    """Render a list of similarly-shaped dicts as a constant-factored table."""
+    if len(items) < MIN_TABLE_ROWS or not all(isinstance(i, dict) for i in items):
+        return None
+
+    keys: dict[str, None] = {}  # ordered union of keys across all items
+    for item in items:
+        keys.update(dict.fromkeys(item))
+
+    cells = [{k: _dumps(item[k]) for k in item} for item in items]
+    constant = [
+        k
+        for k in keys
+        if all(k in c for c in cells) and len({c[k] for c in cells}) == 1
+    ]
+    varying = [k for k in keys if k not in constant]
+
+    lines = [
+        f"'{title}': {len(items)} items as a table"
+        " (each row is one item; combine with the constant fields):"
+    ]
+    if constant:
+        lines.append(
+            "constant fields (identical for every item): "
+            + _dumps({k: items[0][k] for k in constant})
+        )
+    if varying:
+        lines.append(" | ".join(varying))
+        lines.extend(
+            " | ".join(cell.get(k, "<absent>") for k in varying) for cell in cells
+        )
+    return "\n".join(lines)
+
+
+def _dumps(value: Any) -> str:
+    return json.dumps(value, separators=(",", ":"), default=str)

--- a/tiger_agent/compression.py
+++ b/tiger_agent/compression.py
@@ -2,16 +2,22 @@
 
 Large tool results (issue lists, search hits, query results) are dominated by
 JSON arrays of similarly-shaped objects, and most of their bulk is object keys
-repeated per item plus field values shared by every item. Rendering such
-arrays as a table with the constant fields factored out removes that
-redundancy without dropping any items. Results that aren't shaped this way
-(plain text, binary content, irregular JSON) pass through untouched.
+repeated per item. Re-encoding such results as TOON (Token-Oriented Object
+Notation) factors those keys out: a uniform array of flat objects becomes a
+table whose columns are declared once, dropping the per-row key repetition
+without losing any items. Results that don't benefit (plain text, binary
+content, irregular or deeply nested JSON) fall through untouched.
+
+TOON encoding is lossless: `toons.loads(toons.dumps(obj)) == obj`. The
+threshold and ratio gates below mean a compacted result reaches the model only
+when it is meaningfully smaller than the original JSON; otherwise the original
+is returned unchanged.
 """
 
 import json
 import logging
-from typing import Any
 
+import toons
 from pydantic_ai.mcp import ToolResult
 
 logger = logging.getLogger(__name__)
@@ -20,16 +26,14 @@ logger = logging.getLogger(__name__)
 # costs more than it saves.
 MIN_COMPRESSABLE_CHARS = 4_000
 
-# Arrays with fewer items than this stay as JSON; tables only pay off when
-# keys repeat enough times.
-MIN_TABLE_ROWS = 5
-
-# Keep the original unless the compacted form is at least 20% smaller.
+# Keep the original unless the compacted form is at least 20% smaller. TOON only
+# wins decisively on flat uniform arrays; nested or irregular shapes encode to
+# roughly the same size as JSON and are left as JSON by this gate.
 MAX_COMPACT_RATIO = 0.8
 
 
 def compress_tool_result(result: ToolResult) -> ToolResult:
-    """Compact a large JSON tool result; return the original if not applicable."""
+    """Compact a large JSON tool result via TOON; return the original if not applicable."""
     try:
         if isinstance(result, str):
             try:
@@ -46,8 +50,11 @@ def compress_tool_result(result: ToolResult) -> ToolResult:
         if original_len < MIN_COMPRESSABLE_CHARS:
             return result
 
-        compacted = _compact(obj)
-        if compacted is not None and len(compacted) < original_len * MAX_COMPACT_RATIO:
+        if not isinstance(obj, (dict, list)):
+            return result
+
+        compacted = toons.dumps(obj)
+        if len(compacted) < original_len * MAX_COMPACT_RATIO:
             logger.info(
                 "compacted tool result from %d to %d chars",
                 original_len,
@@ -57,60 +64,3 @@ def compress_tool_result(result: ToolResult) -> ToolResult:
     except Exception:
         logger.exception("tool result compaction failed, returning original")
     return result
-
-
-def _compact(obj: Any) -> str | None:
-    if isinstance(obj, list):
-        return _tabulate(obj, title="items")
-
-    if isinstance(obj, dict):
-        tables = []
-        remainder = dict(obj)
-        for key, value in obj.items():
-            table = _tabulate(value, title=key) if isinstance(value, list) else None
-            if table is not None:
-                remainder[key] = f"<{len(value)} items, see table '{key}' below>"
-                tables.append(table)
-        if not tables:
-            return None
-        return "\n\n".join([_dumps(remainder), *tables])
-
-    return None
-
-
-def _tabulate(items: list[Any], title: str) -> str | None:
-    """Render a list of similarly-shaped dicts as a constant-factored table."""
-    if len(items) < MIN_TABLE_ROWS or not all(isinstance(i, dict) for i in items):
-        return None
-
-    keys: dict[str, None] = {}  # ordered union of keys across all items
-    for item in items:
-        keys.update(dict.fromkeys(item))
-
-    cells = [{k: _dumps(item[k]) for k in item} for item in items]
-    constant = [
-        k
-        for k in keys
-        if all(k in c for c in cells) and len({c[k] for c in cells}) == 1
-    ]
-    varying = [k for k in keys if k not in constant]
-
-    lines = [
-        f"'{title}': {len(items)} items as a table"
-        " (each row is one item; combine with the constant fields):"
-    ]
-    if constant:
-        lines.append(
-            "constant fields (identical for every item): "
-            + _dumps({k: items[0][k] for k in constant})
-        )
-    if varying:
-        lines.append(" | ".join(varying))
-        lines.extend(
-            " | ".join(cell.get(k, "<absent>") for k in varying) for cell in cells
-        )
-    return "\n".join(lines)
-
-
-def _dumps(value: Any) -> str:
-    return json.dumps(value, separators=(",", ":"), default=str)

--- a/tiger_agent/utils.py
+++ b/tiger_agent/utils.py
@@ -30,6 +30,7 @@ from slack_bolt.async_app import AsyncApp
 
 from tiger_agent import __version__
 from tiger_agent.agent.types import AgentResponseContext
+from tiger_agent.compression import compress_tool_result
 from tiger_agent.db.utils import create_default_pool
 from tiger_agent.mcp.types import MCPDict
 from tiger_agent.salesforce.clients import get_salesforce_api_client
@@ -117,6 +118,7 @@ def setup_logging(service_name: str = "tiger-agent") -> None:
 
 def create_wrapped_process_tool_call(
     existing_func: ProcessToolCallback | None,
+    compress_results: bool = False,
 ) -> ProcessToolCallback:
     async def process_tool_call(
         ctx: RunContext[AgentResponseContext],
@@ -126,27 +128,33 @@ def create_wrapped_process_tool_call(
     ):
         try:
             if existing_func is not None:
-                return await existing_func(ctx, call_tool, name, tool_args)
-
-            return await call_tool(name, tool_args, None)
+                result = await existing_func(ctx, call_tool, name, tool_args)
+            else:
+                result = await call_tool(name, tool_args, None)
+            return compress_tool_result(result) if compress_results else result
         except Exception as ex:
             logfire.exception(
                 "Exception occurred during tool call", name=name, tool_args=tool_args
             )
-            message = f"Tool call failed, could not retrieve information. Error: {ex.message or ex}"
+            message = f"Tool call failed, could not retrieve information. Error: {getattr(ex, 'message', None) or ex}"
             return message
 
     return process_tool_call
 
 
-def wrap_mcp_servers_with_exception_handling(mcp_servers: MCPDict) -> MCPDict:
+def wrap_mcp_servers_with_exception_handling(
+    mcp_servers: MCPDict, compress_tool_results: bool = False
+) -> MCPDict:
     """Wrap MCP servers with exception handling for tool calls.
 
     Creates wrapper functions around existing process_tool_call methods
-    to add consistent error handling and logging.
+    to add consistent error handling and logging, and optionally compact
+    oversized tool results before they reach the model.
 
     Args:
         mcp_servers: Dictionary of MCP server configurations
+        compress_tool_results: Compact large JSON tool results (see
+            tiger_agent.compression)
 
     Returns:
         Modified dictionary with wrapped process_tool_call functions
@@ -155,7 +163,7 @@ def wrap_mcp_servers_with_exception_handling(mcp_servers: MCPDict) -> MCPDict:
         existing_process_tool_call = value.mcp_server.process_tool_call
 
         value.mcp_server.process_tool_call = create_wrapped_process_tool_call(
-            existing_process_tool_call
+            existing_process_tool_call, compress_results=compress_tool_results
         )
 
     return mcp_servers
@@ -215,7 +223,9 @@ def _to_yaml(value: Any, indent: int = 0) -> str:
                 lines.append(f"{pad}{k}: {rendered}")
         return "\n".join(lines)
     if isinstance(value, list):
-        items = [f"{pad}- {_to_yaml(v, indent + 1).lstrip()}" for v in value if v is not None]
+        items = [
+            f"{pad}- {_to_yaml(v, indent + 1).lstrip()}" for v in value if v is not None
+        ]
         return "\n".join(items)
     return str(value)
 

--- a/uv.lock
+++ b/uv.lock
@@ -979,6 +979,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "isodate"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1721,6 +1730,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -2204,6 +2222,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -2731,6 +2765,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -2753,7 +2788,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.13.1" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "ruff", specifier = ">=0.13.1" },
+]
 
 [[package]]
 name = "tiktoken"

--- a/uv.lock
+++ b/uv.lock
@@ -2759,6 +2759,7 @@ dependencies = [
     { name = "semver" },
     { name = "simple-salesforce" },
     { name = "slack-bolt" },
+    { name = "toons" },
     { name = "tzdata" },
     { name = "websockets" },
 ]
@@ -2783,6 +2784,7 @@ requires-dist = [
     { name = "semver", specifier = ">=3.0.4" },
     { name = "simple-salesforce", specifier = ">=1.12.9" },
     { name = "slack-bolt", specifier = ">=1.26.0" },
+    { name = "toons", specifier = ">=0.7.0" },
     { name = "tzdata", specifier = ">=2025.2" },
     { name = "websockets", specifier = ">=15.0.1" },
 ]
@@ -2857,6 +2859,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
     { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
     { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
+name = "toons"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/23/1d9a6fdc56dccf9c7d22377618adff8d25a12a9214a8fab5c8286e50c527/toons-0.7.0.tar.gz", hash = "sha256:d196a29319bf4ec1481d1f06a05017b859652d112a52eb7071d33c6da28b8193", size = 234510, upload-time = "2026-05-21T21:55:28.754Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/23/b45ad15a8eb21a9109e7fe9bbd04e005b4ea8c35b9dea98023f1a585baeb/toons-0.7.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:08f380080e3a54ad53ed6baa1eaa35d4767a7e31436bd05af97b3cc00a6936b5", size = 304442, upload-time = "2026-05-21T21:55:46.341Z" },
+    { url = "https://files.pythonhosted.org/packages/41/36/dff71444f52f82031c8f4a86f2a212d8d7bdb05e00f8559144e6ff3b31b7/toons-0.7.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30bb78650744dfe53a080d683e5b55c3e90fa24d8f1713bb4237d66282e92d9c", size = 300813, upload-time = "2026-05-21T21:55:31.308Z" },
+    { url = "https://files.pythonhosted.org/packages/19/93/7d5162a15f46ddc794f16aeb0eb8b12e39d02c6a585b13ff2425b8758970/toons-0.7.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b28eb732f13b1909eb0ac9d32f4e39b6f279081fdaf24f0bce320dbf4cde015f", size = 332617, upload-time = "2026-05-21T21:55:29.912Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/24/806d3b3c9d86ca202a858d5dcaa862616cd3ee5e52cf9507b2fe6e3acb4f/toons-0.7.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5468da364bbb3eadd860495148b035f74f9e51b3c83ed8ea9f761938b2a602d1", size = 340984, upload-time = "2026-05-21T21:55:37.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ff/de05d3bbe0c8b860c71d4d025b6306ee66a988efc1bcd3fe43a419cb717a/toons-0.7.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1bb17238ac0853b92f01452c1cf438157b0b4d602ec2e2c9f425ee57cd81a41b", size = 508422, upload-time = "2026-05-21T21:55:32.808Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7b/ecefbc3fd2d89a8240c347bcc81bd19fb821c9b141c3ec3479ce0c9e5af4/toons-0.7.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:637994ae2e58782a35d0c5ab0b16c802624c3e6850da41250ba3c953118bce49", size = 543302, upload-time = "2026-05-21T21:55:35.602Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a6/948b6b2639849d488a6f4310c8f9abb3486250d130e467e758f9ce79b0b2/toons-0.7.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b987602c142b945745b2379b8079171fd6d928b4edd6e2162a3f735db6ca73d7", size = 196411, upload-time = "2026-05-21T21:55:48.712Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4f/4b627ec63f45cafd071b449678567ca57342715dff797159dc34b6e91fa4/toons-0.7.0-cp314-cp314t-win_arm64.whl", hash = "sha256:cac4faa2f3f8da96bc13ccad8cf554f82810f681b02ea27d0a4f79bed3e7ac83", size = 190350, upload-time = "2026-05-21T21:55:38.799Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/43/2d4d6cd43635130154a57fd45cee8494fd66c4ae73d0d9c17331ebf30637/toons-0.7.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7933216d41175af1747d4475ae2f947178ac45fd7f8b839a5bcbda57b5c99301", size = 312469, upload-time = "2026-05-21T21:55:42.833Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e6/cd600e0461cc9e7b74d8723e010da92efe90136350d9835af1a9f10bfa0e/toons-0.7.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:10681fd930ee555df213fe0a19675ddd1095f4291999ab507adb0833fa01e47d", size = 308194, upload-time = "2026-05-21T21:55:41.459Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e5/032c014b33cf954ef502326de78466e6ce440f3419b6c9d54721a895936a/toons-0.7.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b45b0a429c22e3b0e7f658d8cbfeb03b1ab4798b2323c7c119fe5029fdaaf1c", size = 339568, upload-time = "2026-05-21T21:55:47.351Z" },
+    { url = "https://files.pythonhosted.org/packages/41/39/6e3c0752b7a1f693fb7082ecc5d3757884537a102d2c846a5a24d7de4b47/toons-0.7.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18fd8f455c2bfa6655c4eaf931dd8e321be0b53a4f2acbc91e77f72843a0f7b9", size = 348803, upload-time = "2026-05-21T21:55:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/bd/d495738cc5e1c201a864a75b0520fdb74fcd2a8c631a61efc993fb8f992f/toons-0.7.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7e92ed900fee3a7db0467573bba29c876a1701827836b895d13891a3f5d04567", size = 516042, upload-time = "2026-05-21T21:55:49.827Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/bb5f09db2100631bef2ab39545611958545f6ef3b7d0f56d85af341fd0f8/toons-0.7.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:611d3db35614ec8f5f7c00accb38787c4db0e34f98bdbc0746e196cab32d45ba", size = 551947, upload-time = "2026-05-21T21:55:39.868Z" },
+    { url = "https://files.pythonhosted.org/packages/65/fa/43f86b3862448159ca6434942822aa31dec02b848967474e94cc1f568154/toons-0.7.0-cp37-abi3-win_amd64.whl", hash = "sha256:56c79eb7e3a9155a564f5ca1fe10f2a93e0e534c82bc9d7c7c047267e472a2f5", size = 202369, upload-time = "2026-05-21T21:55:44.928Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9e/bfa4d07d215ea248818b85bc1bec8664eec1728e0704c773a252c4ac7d82/toons-0.7.0-cp37-abi3-win_arm64.whl", hash = "sha256:b1f53e0c9f40439f426050050f34a1e8b495ff4f702bfa460142929ad7e08c8c", size = 196225, upload-time = "2026-05-21T21:55:27.253Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Three token-efficiency changes to the harness, each independently tunable:

1. **Prompt caching, on by default.** `TigerAgent` gains `anthropic_cache_ttl: Literal["5m", "1h"] | None = "5m"`. When set (the default), `create_agent_and_context` passes pydantic-ai's `anthropic_cache_tool_definitions`, `anthropic_cache_instructions`, and `anthropic_cache_messages` settings, placing cache points on the tool definitions, system prompt, and message history. Each iteration of the agentic loop then re-reads that prefix at ~0.1x input price instead of full price (5m cache writes cost 1.25x, so caching pays for itself after one read). Pass `"1h"` for bursty workloads with gaps over 5 minutes, or `None` to disable. Uses 3 of Anthropic's 4 cache points; nothing else in the library places cache points.

2. **Tool result compaction, on by default** (`tiger_agent/compression.py`, new). Large MCP tool results (issue lists, search hits) are dominated by JSON arrays of similarly-shaped objects, where most of the bulk is object keys repeated per item plus field values identical across items. The module renders such arrays as a table (keys emitted once as a header) with constant fields factored out into a single line. All items are preserved; nothing is sampled or dropped. Stdlib-only. Wired into `wrap_mcp_servers_with_exception_handling` so per-server `process_tool_call` hooks compose with it (the hook runs first, its result gets compacted). Tunable via `compress_tool_results: bool = True` on `TigerAgent`.

   Guardrails: only fires on results > 4,000 chars that parse as JSON and contain an array of 5+ dicts; only adopted when at least 20% smaller; plain text, binary, small, and irregular results pass through untouched; any exception falls back to the original result.

3. **1M context beta header gated by model.** `context-1m-2025-08-07` was sent for every Anthropic model. Sonnet 4.6+ and Opus 4.6+ include the 1M window at standard pricing and don't need it, while on Sonnet 4.5/4 the header bills requests over 200K input tokens at premium long-context rates. It's now only sent for the models that require it (`LONG_CONTEXT_BETA_MODELS`).

Also fixes a latent bug in the tool-call exception handler: `ex.message or ex` raises `AttributeError` on standard Python exceptions (no `.message` attribute), letting the original exception escape the wrapper. Now `getattr(ex, "message", None) or ex`; errors that do carry `.message` render identically.

Consumers need no code change; existing constructor calls pick up both defaults.

## Verification

`ruff format` / `ruff check` pass on all four touched files. Behavior checks (output verbatim):

Caching settings assembly:
```
default 4.6:    {'anthropic_cache_tool_definitions': '5m', 'anthropic_cache_instructions': '5m', 'anthropic_cache_messages': '5m'}
1h ttl:         {'anthropic_cache_tool_definitions': '1h', 'anthropic_cache_instructions': '1h', 'anthropic_cache_messages': '1h'}
cache off 4.6:  None
cache off 4.5:  {'extra_headers': {'anthropic-beta': 'context-1m-2025-08-07'}}
```

Wrapper composition (async, through `create_wrapped_process_tool_call`):
```
compression on:   15130 -> 1187 chars
compression off:  passed through untouched (back-compat default)
small result:     passed through untouched
existing hook:    still runs, its result compressed
exceptions: caught -> Tool call failed, could not retrieve information. Error: kapow
exceptions: .message-bearing errors unchanged -> Tool call failed, ... Error: mcp-style message attr
```

On a separate 60-item GitHub-style payload with a shared long description: 54,220 -> 1,947 chars (97% saved). Realistic Linear-style envelope with 40 varied items: 7,599 -> 4,288 (44% saved).

The three cache settings exist and accept these values in pydantic-ai 1.70.0 (this repo's lock) and back through at least 1.56.0, so the `>=1.28.0` floor is unaffected for current consumers.

After a consumer deploys, confirm caching lands by checking `cache_read_input_tokens > 0` on second+ iterations of tool-calling runs, and watch for `compacted tool result from X to Y chars` info logs (both visible in Logfire).

## Future pydantic-ai update

Newer pydantic-ai (post-1.70) adds a top-level `anthropic_cache` setting, the now-preferred way to cache message history: the server auto-places the breakpoint, and `anthropic_cache_messages` is relegated to a fallback for gateways that don't support top-level cache_control (the two are mutually exclusive). When this repo bumps pydantic-ai past that version, swap `anthropic_cache_messages` for `anthropic_cache` in `create_agent_and_context` (one line); the other two settings stay as-is.