### PR TITLE
[AGE-514] Create a thread when a new case is created and is determined to be spam

### DIFF
--- a/tiger_agent/agent/types.py
+++ b/tiger_agent/agent/types.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field
 
 from tiger_agent.salesforce.types import (
     SalesforceAssignmentChangedEvent,
+    SalesforceCaseCreatedEvent,
     SalesforceCaseStatusChangedEvent,
     SalesforceCreateNewCaseEvent,
     SalesforceFeedItemEvent,
@@ -44,6 +45,7 @@ class AgentResponseContext(BaseModel):
         | SlackSalesforceCaseThreadMessageEvent
         | SalesforceCreateNewCaseEvent
         | SalesforceAssignmentChangedEvent
+        | SalesforceCaseCreatedEvent
         | SalesforceFeedItemEvent
         | SalesforceCaseStatusChangedEvent
         | AgentFeedbackRatingEvent

--- a/tiger_agent/app.py
+++ b/tiger_agent/app.py
@@ -6,6 +6,7 @@ from tiger_agent.agent.tiger_agent import TigerAgent
 from tiger_agent.listeners.harness import ListenerHarness
 from tiger_agent.salesforce.types import (
     SalesforceAssignmentChangedEvent,
+    SalesforceCaseCreatedEvent,
     SalesforceCaseStatusChangedEvent,
     SalesforceCreateNewCaseEvent,
     SalesforceFeedItemEvent,
@@ -22,6 +23,7 @@ from tiger_agent.tasks.handlers import (
     AgentFeedbackRatingHandler,
     AgentFeedbackRequestReminderHandler,
     SalesforceAssignmentChangedHandler,
+    SalesforceCaseCreatedHandler,
     SalesforceCaseStatusChangedHandler,
     SalesforceCreateCaseHandler,
     SalesforceFeedItemHandler,
@@ -106,6 +108,10 @@ class TigerApp:
         processor.register(
             [SlackAppMentionEvent, SlackMessageEvent],
             SlackTaskHandler(hctx=hctx, agent=agent),
+        )
+        processor.register(
+            SalesforceCaseCreatedEvent,
+            SalesforceCaseCreatedHandler(hctx=hctx, agent=agent),
         )
         processor.register(
             SalesforceAssignmentChangedEvent,

--- a/tiger_agent/listeners/salesforce.py
+++ b/tiger_agent/listeners/salesforce.py
@@ -202,7 +202,7 @@ class SalesforceListener(Listener):
             self._upsert_case_push_topic_definition(
                 topic_name=topic_name,
                 fields=fields,
-                notifyOnCreate=notify_on != "update",
+                notifyOnCreate=notify_on == "create",
                 notifyOnUpdate=notify_on == "update",
             )
             await subscribe_to_topic(

--- a/tiger_agent/listeners/salesforce.py
+++ b/tiger_agent/listeners/salesforce.py
@@ -3,7 +3,7 @@ import re
 from asyncio import TaskGroup
 from collections.abc import Callable, Coroutine
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 import logfire
 import schedule
@@ -25,6 +25,7 @@ from tiger_agent.salesforce.new_case_poller import SalesforceNewCasePoller
 from tiger_agent.salesforce.types import (
     CaseData,
     SalesforceAssignmentChangedEvent,
+    SalesforceCaseCreatedEvent,
     SalesforceCaseStatusChangedEvent,
     SalesforceFeedItem,
     SalesforceFeedItemEvent,
@@ -37,6 +38,7 @@ from tiger_agent.types import HarnessContext
 
 CASE_OWNER_CHANGED_TOPIC = "CaseOwnerChangedTopic"
 CASE_STATUS_CHANGED_TOPIC = "CaseStatusChangedTopic"
+CASE_CREATED_TOPIC = "CaseCreatedTopic"
 
 
 class SalesforceListener(Listener):
@@ -68,6 +70,14 @@ class SalesforceListener(Listener):
                 CASE_OWNER_CHANGED_TOPIC,
                 [CASE_ID_FIELD, CASE_OWNER_ID_FIELD],
                 self.handle_updated_case_assignee,
+            )
+        )
+        tasks.create_task(
+            self._subscribe_to_event(
+                CASE_CREATED_TOPIC,
+                [CASE_ID_FIELD, CASE_OWNER_ID_FIELD],
+                self.handle_case_created,
+                "create",
             )
         )
         tasks.create_task(
@@ -159,18 +169,41 @@ class SalesforceListener(Listener):
 
         await self._trigger.put(True)
 
+    @logfire.instrument("handle_case_created", extract_args=["case"])
+    async def handle_case_created(self, case: CaseData):
+        if not SALESFORCE_CASE_CHANNEL:
+            logfire.warn(
+                "A new case was created, but no Slack channel configured",
+                extra={"case": case.model_dump_json()},
+            )
+            return
+
+        if should_ignore_new_case(case):
+            logfire.info("Ignoring case")
+            return
+
+        full_case_data = self._salesforce_client.Case.get(case.Id)
+
+        await insert_event(
+            pool=self._pool,
+            event=SalesforceCaseCreatedEvent(case=full_case_data).model_dump(),
+        )
+
+        await self._trigger.put(True)
+
     async def _subscribe_to_event(
         self,
         topic_name: str,
         fields: list[str],
         handler: Callable[[CaseData], Coroutine[Any, Any, None]],
+        notify_on: Literal["update", "create"] | None = "update",
     ):
         try:
             self._upsert_case_push_topic_definition(
                 topic_name=topic_name,
                 fields=fields,
-                notifyOnCreate=False,
-                notifyOnUpdate=True,
+                notifyOnCreate=notify_on != "update",
+                notifyOnUpdate=notify_on == "update",
             )
             await subscribe_to_topic(
                 salesforce_client=self._salesforce_client,

--- a/tiger_agent/salesforce/types.py
+++ b/tiger_agent/salesforce/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 from pydantic import BaseModel, field_validator
 
@@ -61,7 +61,7 @@ class SalesforceCreateNewCaseEvent(SalesforceBaseEvent):
     """Pydantic model for Salesforce new case event."""
 
     type: str = "salesforce_event"
-    subtype: str = "create_new_case"
+    subtype: Literal["create_new_case"] = "create_new_case"
     event_description: ClassVar[str] = (
         "A user submitted a request to open a new Salesforce support case (the case has not yet been created)"
     )
@@ -78,12 +78,23 @@ class SalesforceAssignmentChangedEvent(SalesforceBaseEvent):
     """Pydantic model for Salesforce new case event."""
 
     type: str = "salesforce_event"
-    subtype: str = "new_assignee"
+    subtype: Literal["new_assignee"] = "new_assignee"
     event_description: ClassVar[str] = (
         "A new Salesforce support case has been created — use this to monitor for new cases"
     )
     case: CaseData
     update_link_to_thread: bool = True
+
+
+class SalesforceCaseCreatedEvent(SalesforceBaseEvent):
+    """Pydantic model for Salesforce new case event."""
+
+    type: str = "salesforce_event"
+    subtype: Literal["case_created"] = "case_created"
+    event_description: ClassVar[str] = (
+        "A new Salesforce support case has been created, but not assigned —  do not use this to monitor for new cases"
+    )
+    case: CaseData
 
 
 class SalesforceFeedItemCreatedBy(BaseModel):
@@ -121,7 +132,7 @@ class SalesforceFeedItemEvent(SalesforceBaseEvent):
     """Pydantic model for a new Salesforce FeedItem (Chatter post) on a case."""
 
     type: str = "salesforce_event"
-    subtype: str = "new_feed_item"
+    subtype: Literal["new_feed_item"] = "new_feed_item"
     event_description: ClassVar[str] = (
         "A new message posted to a Salesforce case feed (e.g. a customer reply or engineer response)"
     )
@@ -132,7 +143,7 @@ class SalesforceCaseStatusChangedEvent(SalesforceBaseEvent):
     """Pydantic model for a Salesforce case closed event."""
 
     type: str = "salesforce_event"
-    subtype: str = "case_status_changed"
+    subtype: Literal["case_status_changed"] = "case_status_changed"
     event_description: ClassVar[str] = (
         "A Salesforce case status changed (e.g. New → In Progress → Closed)"
     )

--- a/tiger_agent/salesforce/utils.py
+++ b/tiger_agent/salesforce/utils.py
@@ -373,6 +373,26 @@ def add_case_email_comment(
         )
 
 
+def add_internal_case_post(
+    salesforce_client: Salesforce,
+    case_id: str,
+    body: str,
+) -> None:
+    result = salesforce_client.FeedItem.create(
+        {
+            "ParentId": case_id,
+            "Body": body,
+            "Visibility": "InternalUsers",
+            "IsRichText": False,
+        }
+    )
+    if not result["success"] or not result["id"]:
+        logfire.error(
+            "Could not add internal post to Salesforce case",
+            extra={"case_id": case_id},
+        )
+
+
 def get_case_feed_items(
     salesforce_client: Salesforce,
     case_id: str | None = None,

--- a/tiger_agent/slack/utils.py
+++ b/tiger_agent/slack/utils.py
@@ -12,6 +12,7 @@ All functions are designed to be resilient, gracefully handling API errors and p
 structured data models for Slack entities.
 """
 
+import asyncio
 import json
 import re
 from collections.abc import Sequence
@@ -1140,3 +1141,17 @@ async def get_a_href_link_to_user_profile(
         return f'<a href="{user_profile_url}">@{user_info.name}</a>'
 
     return f"@{user_info.name}"
+
+
+def request_feedback(client: AsyncWebClient, channel: str, thread_ts: str) -> None:
+    async def _delayed_feedback(client, channel, message_ts):
+        await asyncio.sleep(10)
+        await send_feedback_button(client=client, channel=channel, thread_ts=message_ts)
+
+    asyncio.create_task(
+        _delayed_feedback(
+            client,
+            channel=channel,
+            message_ts=thread_ts,
+        )
+    )

--- a/tiger_agent/tasks/handlers.py
+++ b/tiger_agent/tasks/handlers.py
@@ -36,6 +36,7 @@ from tiger_agent.salesforce.constants import (
 from tiger_agent.salesforce.types import (
     SalesforceAssignmentChangedEvent,
     SalesforceBaseEvent,
+    SalesforceCaseCreatedEvent,
     SalesforceCaseStatusChangedEvent,
     SalesforceCreateNewCaseEvent,
     SalesforceFeedItemEvent,
@@ -43,6 +44,7 @@ from tiger_agent.salesforce.types import (
 )
 from tiger_agent.salesforce.utils import (
     add_case_email_comment,
+    add_internal_case_post,
     build_email_attachments_from_slack_files,
     create_case,
     create_case_url,
@@ -70,7 +72,7 @@ from tiger_agent.slack.utils import (
     get_channel_link,
     get_handle_link,
     post_response,
-    send_feedback_button,
+    request_feedback,
     set_status,
     stream_response_to_mention,
     user_is_external,
@@ -267,6 +269,7 @@ class SalesforceAssignmentChangedHandler(TaskHandler):
             client=hctx.app.client,
             channel=SALESFORCE_CASE_CHANNEL,
             thread_ts=None,
+            use_mrkdwn=True,
             text=f"*New Case* <{create_case_url(event.case.Id)}|{event.case.CaseNumber}> - _{event.case.Subject}_{f', assigned to {get_handle_link(case_owner_user_id)}' if case_owner_user_id else ''}:thread: \n```\n{response.output.short_description_of_case}\n```",
         )
 
@@ -319,19 +322,95 @@ class SalesforceAssignmentChangedHandler(TaskHandler):
                     reminder_datetime=users_end_of_day,
                 )
 
-            async def _delayed_feedback(client, channel, message_ts):
-                await asyncio.sleep(10)
-                await send_feedback_button(
-                    client=client, channel=channel, thread_ts=message_ts
-                )
-
-            asyncio.create_task(
-                _delayed_feedback(
-                    hctx.app.client,
-                    channel=message_to_link_to.channel_id,
-                    message_ts=message_to_link_to.ts,
-                )
+            request_feedback(
+                hctx.app.client,
+                channel=message_to_link_to.channel_id,
+                thread_ts=message_to_link_to.ts,
             )
+
+
+class SalesforceCaseCreatedHandler(TaskHandler):
+    """
+    Runs the agent to determine if the case is spam.
+    We handle legitimate new cases with the SalesforceAssignmentChangedHandler
+    as, at that point we have a assignee and spam should have been filtered out
+    So this handler is strictly to detect spam cases
+    """
+
+    def __init__(self, hctx: HarnessContext, agent: TigerAgent) -> None:
+        super().__init__(hctx)
+        self._agent = agent
+
+    @logfire.instrument("SalesforceCaseCreatedHandler.handle", extract_args=False)
+    async def handle(self, task: Task) -> None:
+        hctx = self._hctx
+        event: SalesforceCaseCreatedEvent = task.event
+
+        if not SALESFORCE_ENABLE_SPAM_FILTERING:
+            return
+
+        agent_and_ctx = await create_agent_and_context(
+            hctx=hctx,
+            task=task,
+            agent=self._agent,
+            channel_to_respond=SALESFORCE_CASE_CHANNEL,
+        )
+
+        response = await agent_and_ctx.agent.run(
+            user_prompt=agent_and_ctx.user_prompt,
+            deps=agent_and_ctx.ctx,
+            usage_limits=UsageLimits(output_tokens_limit=9_000),
+        )
+
+        if not response.output.is_spam:
+            return
+
+        logfire.info(
+            "Salesforce case identified as spam",
+            extra={"filtering_enabled": SALESFORCE_ENABLE_SPAM_FILTERING},
+        )
+
+        original_message = await post_response(
+            client=hctx.app.client,
+            channel=SALESFORCE_CASE_CHANNEL,
+            thread_ts=None,
+            use_mrkdwn=True,
+            text=f"*Spam Detected* <{create_case_url(event.case.Id)}|{event.case.CaseNumber}> - _{event.case.Subject}_",
+        )
+
+        message_to_link_to = SlackMessage(
+            channel_id=SALESFORCE_CASE_CHANNEL,
+            ts=original_message.data.get("ts"),
+            text=response.output.message,
+            thread_ts=None,
+        )
+
+        if message_to_link_to and SALESFORCE_SLACK_THREAD_FIELD:
+            result = await hctx.app.client.chat_getPermalink(
+                channel=message_to_link_to.channel_id,
+                message_ts=message_to_link_to.ts,
+            )
+            permalink = result.data.get("permalink")
+            hctx.salesforce_client.Case.update(
+                event.case.Id,
+                {SALESFORCE_SLACK_THREAD_FIELD: permalink},
+                headers={"Sforce-Auto-Assign": "false"},
+            )
+            logfire.info(
+                "Updated Salesforce case to include the thread link",
+                extra={"permalink": permalink},
+            )
+
+        add_internal_case_post(
+            salesforce_client=hctx.salesforce_client,
+            case_id=event.case.Id,
+            body=response.output.short_description_of_case,
+        )
+        request_feedback(
+            hctx.app.client,
+            channel=message_to_link_to.channel_id,
+            thread_ts=message_to_link_to.ts,
+        )
 
 
 class AgentFeedbackRequestReminderHandler(TaskHandler):
@@ -676,7 +755,9 @@ class UserDefinedRuleMatchHandler(TaskHandler):
             ),
             tools=[
                 Tool(_send_dm, takes_ctx=False, name="send_dm"),
-                Tool(_send_channel_message, takes_ctx=False, name="send_channel_message"),
+                Tool(
+                    _send_channel_message, takes_ctx=False, name="send_channel_message"
+                ),
                 Tool(_get_case_url, takes_ctx=False, name="get_case_url"),
             ],
         )

--- a/tiger_agent/tasks/types.py
+++ b/tiger_agent/tasks/types.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 
 from tiger_agent.salesforce.types import (
     SalesforceAssignmentChangedEvent,
+    SalesforceCaseCreatedEvent,
     SalesforceCaseStatusChangedEvent,
     SalesforceCreateNewCaseEvent,
     SalesforceFeedItemEvent,
@@ -44,6 +45,7 @@ class Task(BaseModel):
         | SlackMessageEvent
         | SalesforceCreateNewCaseEvent
         | SalesforceAssignmentChangedEvent
+        | SalesforceCaseCreatedEvent
         | SalesforceFeedItemEvent
         | SalesforceCaseStatusChangedEvent
         | AgentFeedbackRatingEvent


### PR DESCRIPTION
## What
* adds a new case event Salesforce listener (our current "new case" listener actually triggers on case assignee changed)
* when a case is determined to be spam, post a minimal *spam detected* message, request feedback, then add an internal comment on the case

## Other
* use markdown for new case post (so bold works)
* add better literal discriminator field types for pydantic models


## Demo

### Slack message
<img width="420" height="117" alt="image" src="https://github.com/user-attachments/assets/ecc0d4a4-b40a-40aa-836f-f4fd9eb9cf25" />


### Comment on case
<img width="849" height="239" alt="image" src="https://github.com/user-attachments/assets/3e288e7a-327a-45c6-8841-c6f56bf5cdb1" />
