### PR TITLE
[CHORE] Remove markdown formatting for the Saleforce alerts

### DIFF
--- a/tiger_agent/salesforce/utils.py
+++ b/tiger_agent/salesforce/utils.py
@@ -373,10 +373,6 @@ def add_case_email_comment(
         )
 
 
-def slack_safe_subject(subject: str | None) -> str:
-    return (subject or "").replace("-", "‑")
-
-
 def add_internal_case_post(
     salesforce_client: Salesforce,
     case_id: str,

--- a/tiger_agent/tasks/handlers.py
+++ b/tiger_agent/tasks/handlers.py
@@ -270,7 +270,6 @@ class SalesforceAssignmentChangedHandler(TaskHandler):
             client=hctx.app.client,
             channel=SALESFORCE_CASE_CHANNEL,
             thread_ts=None,
-            use_mrkdwn=True,
             text=f"*New Case* <{create_case_url(event.case.Id)}|{event.case.CaseNumber}> - _{slack_safe_subject(event.case.Subject)}_{f', assigned to {get_handle_link(case_owner_user_id)}' if case_owner_user_id else ''}:thread: \n```\n{response.output.short_description_of_case}\n```",
         )
 
@@ -375,7 +374,6 @@ class SalesforceCaseCreatedHandler(TaskHandler):
             client=hctx.app.client,
             channel=SALESFORCE_CASE_CHANNEL,
             thread_ts=None,
-            use_mrkdwn=True,
             text=f"*Spam Detected* <{create_case_url(event.case.Id)}|{event.case.CaseNumber}> - _{slack_safe_subject(event.case.Subject)}_",
         )
 

--- a/tiger_agent/tasks/handlers.py
+++ b/tiger_agent/tasks/handlers.py
@@ -51,7 +51,6 @@ from tiger_agent.salesforce.utils import (
     download_feed_attachment,
     get_feed_attachment_ids,
     replace_all_slack_mentions_with_links_to_profile,
-    slack_safe_subject,
 )
 from tiger_agent.slack.constants import AGENT_FEEDBACK_RECEIVED_SLACK_CHANNEL
 from tiger_agent.slack.types import (
@@ -270,7 +269,7 @@ class SalesforceAssignmentChangedHandler(TaskHandler):
             client=hctx.app.client,
             channel=SALESFORCE_CASE_CHANNEL,
             thread_ts=None,
-            text=f"*New Case* <{create_case_url(event.case.Id)}|{event.case.CaseNumber}> - _{slack_safe_subject(event.case.Subject)}_{f', assigned to {get_handle_link(case_owner_user_id)}' if case_owner_user_id else ''}:thread: \n```\n{response.output.short_description_of_case}\n```",
+            text=f"*New Case* <{create_case_url(event.case.Id)}|{event.case.CaseNumber}> - _{event.case.Subject}_{f', assigned to {get_handle_link(case_owner_user_id)}' if case_owner_user_id else ''}:thread: \n```\n{response.output.short_description_of_case}\n```",
         )
 
         message_to_link_to = SlackMessage(
@@ -374,7 +373,7 @@ class SalesforceCaseCreatedHandler(TaskHandler):
             client=hctx.app.client,
             channel=SALESFORCE_CASE_CHANNEL,
             thread_ts=None,
-            text=f"*Spam Detected* <{create_case_url(event.case.Id)}|{event.case.CaseNumber}> - _{slack_safe_subject(event.case.Subject)}_",
+            text=f"*Spam Detected* <{create_case_url(event.case.Id)}|{event.case.CaseNumber}> - _{event.case.Subject}_",
         )
 
         message_to_link_to = SlackMessage(


### PR DESCRIPTION
## What
Roll back the markdown usage because we are having line breaks where there shouldn't be 
<img width="595" height="811" alt="image" src="https://github.com/user-attachments/assets/9697ceac-0a31-4610-8bd2-5c4dad9cdff4" />


## Related PRs
https://github.com/timescale/tiger-agents-for-work/pull/226
https://github.com/timescale/tiger-agents-for-work/pull/225