### PR TITLE
[AGE-534] stream to correct team

### DIFF
--- a/tiger_agent/slack/types.py
+++ b/tiger_agent/slack/types.py
@@ -216,6 +216,7 @@ class SlackBaseEvent(BaseModel):
         blocks: Slack Block Kit blocks if present
         channel: Channel ID where the mention occurred
         event_ts: Event timestamp from Slack
+        user_team: The sender's home workspace
     """
 
     model_config = {"extra": "allow"}
@@ -231,6 +232,7 @@ class SlackBaseEvent(BaseModel):
     channel: str
     event_ts: str
     files: list[SlackFile] | None = None
+    user_team: str | None = None
 
 
 class SlackAppMentionEvent(SlackBaseEvent):

--- a/tiger_agent/slack/utils.py
+++ b/tiger_agent/slack/utils.py
@@ -581,6 +581,16 @@ async def append_message_to_stream(
         raise error
 
 
+@logfire.instrument(
+    "stream_response_to_mention",
+    extract_args=[
+        "channel_id",
+        "ts",
+        "thread_ts",
+        "recipient_user_id",
+        "recipient_team_id",
+    ],
+)
 async def stream_response_to_mention(
     client: AsyncWebClient,
     slack_stream: AsyncChatStream | None,

--- a/tiger_agent/tasks/handlers.py
+++ b/tiger_agent/tasks/handlers.py
@@ -224,7 +224,7 @@ class SlackTaskHandler(TaskHandler):
                     stream_event=stream_event,
                     channel_id=event.channel,
                     recipient_user_id=event.user,
-                    recipient_team_id=hctx.bot_info.team_id,
+                    recipient_team_id=event.user_team or hctx.bot_info.team_id,
                     ts=event.ts,
                     thread_ts=event.thread_ts,
                 )


### PR DESCRIPTION
## What
This fixes issue where the stream method is receiving the bot's team id, rather than the user's team id. Also, adds instrumentation on the streaming method.

## Why
So that eon can respond to external users.