### PR TITLE
[AGE-535] when cases are identified as spam, mark the case as a spam case

### DIFF
--- a/tiger_agent/salesforce/utils.py
+++ b/tiger_agent/salesforce/utils.py
@@ -663,3 +663,14 @@ async def replace_all_slack_mentions_with_links_to_profile(
         non_html = non_html.replace(f"<@{match}>", f"@{user_info.name}")
 
     return (html, non_html)
+
+
+def update_case(
+    client: Salesforce, case_id: str, fields_to_update: dict[str, Any]
+) -> None:
+    """Update a Salesforce case, bypassing auto-assignment rules."""
+    client.Case.update(
+        case_id,
+        fields_to_update,
+        headers={"Sforce-Auto-Assign": "false"},
+    )

--- a/tiger_agent/tasks/handlers.py
+++ b/tiger_agent/tasks/handlers.py
@@ -51,6 +51,7 @@ from tiger_agent.salesforce.utils import (
     download_feed_attachment,
     get_feed_attachment_ids,
     replace_all_slack_mentions_with_links_to_profile,
+    update_case,
 )
 from tiger_agent.slack.constants import AGENT_FEEDBACK_RECEIVED_SLACK_CHANNEL
 from tiger_agent.slack.types import (
@@ -309,10 +310,10 @@ class SalesforceAssignmentChangedHandler(TaskHandler):
                     message_ts=message_to_link_to.ts,
                 )
                 permalink = result.data.get("permalink")
-                hctx.salesforce_client.Case.update(
+                update_case(
+                    hctx.salesforce_client,
                     event.case.Id,
                     {SALESFORCE_SLACK_THREAD_FIELD: permalink},
-                    headers={"Sforce-Auto-Assign": "false"},
                 )
                 logfire.info(
                     "Updated Salesforce case to include the thread link",
@@ -404,11 +405,12 @@ class SalesforceCaseCreatedHandler(TaskHandler):
                 message_ts=message_to_link_to.ts,
             )
             permalink = result.data.get("permalink")
-            hctx.salesforce_client.Case.update(
+            update_case(
+                hctx.salesforce_client,
                 event.case.Id,
                 {SALESFORCE_SLACK_THREAD_FIELD: permalink},
-                headers={"Sforce-Auto-Assign": "false"},
             )
+
             logfire.info(
                 "Updated Salesforce case to include the thread link",
                 extra={"permalink": permalink},
@@ -425,10 +427,10 @@ class SalesforceCaseCreatedHandler(TaskHandler):
             thread_ts=message_to_link_to.ts,
         )
 
-        hctx.salesforce_client.Case.update(
-            event.case.id,
+        update_case(
+            hctx.salesforce_client,
+            event.case.Id,
             {"Status": "Spam", "Type": "Spam"},
-            headers={"Sforce-Auto-Assign": "false"},
         )
 
 
@@ -552,11 +554,13 @@ class SalesforceCreateCaseHandler(TaskHandler):
             message_ts=new_case_thread_ts,
         )
         permalink = result.data.get("permalink")
-        hctx.salesforce_client.Case.update(
+
+        update_case(
+            hctx.salesforce_client,
             new_case.Id,
             {SALESFORCE_SLACK_CUSTOMER_THREAD_FIELD: permalink},
-            headers={"Sforce-Auto-Assign": "false"},
         )
+
         logfire.info(
             "Updated Salesforce case to include the customer thread link",
             extra={"permalink": permalink},

--- a/tiger_agent/tasks/handlers.py
+++ b/tiger_agent/tasks/handlers.py
@@ -425,6 +425,12 @@ class SalesforceCaseCreatedHandler(TaskHandler):
             thread_ts=message_to_link_to.ts,
         )
 
+        hctx.salesforce_client.Case.update(
+            event.case.id,
+            {"Status": "Spam", "Type": "Spam"},
+            headers={"Sforce-Auto-Assign": "false"},
+        )
+
 
 class AgentFeedbackRequestReminderHandler(TaskHandler):
     """


### PR DESCRIPTION
## What
At present, this package has a handler for new cases that are identified as spam, however, it is just posting a "spam detected" message in the specified channel. This change will also change the `status` and `type` of case to be `spam`

## Why
Direct request from Irina