### PR TITLE
[AGE-536] disable auto-assignment on case creation

### DIFF
--- a/tiger_agent/salesforce/constants.py
+++ b/tiger_agent/salesforce/constants.py
@@ -1,4 +1,5 @@
 import os
+from types import MappingProxyType
 
 CASE_ID_FIELD = "Id"
 CASE_OWNER_ID_FIELD = "OwnerId"
@@ -48,4 +49,7 @@ SALESFORCE_INTERNAL_FROM_NAME_SUFFIX = os.environ.get(
 SALESFORCE_IGNORE_CONTACT_EMAIL_REGEX = os.environ.get(
     "SALESFORCE_IGNORE_CONTACT_EMAIL_REGEX",
     r"(?i)@(tigerdata|timescale)\.com$",
+)
+SALESFORCE_SKIP_AUTO_ASSIGNMENT_HEADERS = MappingProxyType(
+    {"Sforce-Auto-Assign": "FALSE"}
 )

--- a/tiger_agent/salesforce/utils.py
+++ b/tiger_agent/salesforce/utils.py
@@ -20,6 +20,7 @@ from tiger_agent.salesforce.constants import (
     CASE_FIELDS,
     SALESFORCE_DOMAIN,
     SALESFORCE_IGNORE_CONTACT_EMAIL_REGEX,
+    SALESFORCE_SKIP_AUTO_ASSIGNMENT_HEADERS,
 )
 from tiger_agent.salesforce.types import (
     CaseData,
@@ -204,7 +205,10 @@ def create_case(
         payload["Cloud_Service_ID__c"] = service_id
     if origin:
         payload["Origin"] = origin
-    result = salesforce_client.Case.create(payload)
+
+    result = salesforce_client.Case.create(
+        payload, headers=SALESFORCE_SKIP_AUTO_ASSIGNMENT_HEADERS
+    )
     if not result["success"] or not result["id"]:
         logfire.error("Could not create a new salesforce case")
         return
@@ -672,5 +676,5 @@ def update_case(
     client.Case.update(
         case_id,
         fields_to_update,
-        headers={"Sforce-Auto-Assign": "false"},
+        headers=SALESFORCE_SKIP_AUTO_ASSIGNMENT_HEADERS,
     )


### PR DESCRIPTION
## What
Passes the `{"Sforce-Auto-Assign": "FALSE"}` headers when creating cases.

## Why
So that the account that we give SF is the account that remains on the account

Screenshot has example of auto assignment to aiven -- we want to prevent that.
<img width="1378" height="424" alt="image" src="https://github.com/user-attachments/assets/2bfd366a-5fcb-4eda-8a34-04726a115593" />


