### PR TITLE
[AGE-536] REVERT - should auto assign on new case

### DIFF
--- a/tiger_agent/salesforce/utils.py
+++ b/tiger_agent/salesforce/utils.py
@@ -206,9 +206,7 @@ def create_case(
     if origin:
         payload["Origin"] = origin
 
-    result = salesforce_client.Case.create(
-        payload, headers=SALESFORCE_SKIP_AUTO_ASSIGNMENT_HEADERS
-    )
+    result = salesforce_client.Case.create(payload)
     if not result["success"] or not result["id"]:
         logfire.error("Could not create a new salesforce case")
         return


### PR DESCRIPTION
## What
This reverts https://github.com/timescale/tiger-agents-for-work/pull/233

## Why
The intent was to tell SF not to reassign the *Account* -- but the header tells SF not to auto assign the Owner.