### PR TITLE
[AGE-549] Add ability to fetch users that are in a user group or a channel

### DIFF
--- a/slack-manifest.json
+++ b/slack-manifest.json
@@ -40,7 +40,8 @@
         "im:read",
         "files:read",
         "files:write",
-        "team:read"
+        "team:read",
+        "usergroups:read"
       ]
     }
   },

--- a/tiger_agent/agent/utils.py
+++ b/tiger_agent/agent/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
@@ -39,6 +40,8 @@ from tiger_agent.slack.utils import (
     fetch_bot_info,
     fetch_thread_messages,
     fetch_user_info,
+    find_user_group,
+    get_user_ids_in_user_group,
 )
 from tiger_agent.tasks.types import Task
 from tiger_agent.types import HarnessContext
@@ -176,6 +179,25 @@ async def create_agent_and_context(
             criteria_examples=criteria_examples,
         )
 
+    async def _get_user_ids_in_user_group(group_name_or_id: str) -> list[str] | str:
+        is_group_id = re.match(r"^S[0-9A-Z]{10}$", group_name_or_id)
+
+        group_id: str | None = group_name_or_id if is_group_id else None
+
+        if not is_group_id:
+            group = await find_user_group(
+                client=hctx.app.client, user_group_name=group_name_or_id
+            )
+
+            if not group:
+                return f"Could not find group matching [{group_name_or_id}]"
+
+            group_id = group.id
+
+        return await get_user_ids_in_user_group(
+            client=hctx.app.client, user_group_id=group_id
+        )
+
     # just a wrapper so we can pass the event in closure
     async def _get_tool_calls_for_event(
         lookback_hours: float = 24.0,
@@ -237,6 +259,27 @@ async def create_agent_and_context(
                         "Infer all parameters from the user's request.\n"
                         f"event_type must be one of:\n{event_type_options}\n"
                         "criteria_examples are optional but improve matching accuracy."
+                    ),
+                ),
+                Tool(
+                    _get_user_ids_in_user_group,
+                    takes_ctx=False,
+                    name="get_user_ids_in_user_group",
+                    description=(
+                        "Look up the Slack user IDs of the members of a Slack user group "
+                        "(a.k.a. an @-mentionable group like @eng or @support-oncall).\n\n"
+                        "The `group_name_or_id` argument accepts any of:\n"
+                        "- A group ID (starts with 'S' followed by 10 uppercase alphanumerics, "
+                        "e.g. 'S0123456789'). Slack often surfaces the raw ID inline in messages "
+                        "that reference a group — pass it through directly if you already have it.\n"
+                        "- A group handle (e.g. 'eng' or '@eng' — the leading @ is optional).\n"
+                        "- A group display name (e.g. 'Engineering'). Matching is case-insensitive.\n\n"
+                        "Returns a list of Slack user IDs, or an error string if the group could "
+                        "not be found or the lookup failed.\n\n"
+                        'Use when the user asks things like "who is in the @eng group?", '
+                        '"list members of the on-call rotation", or "who is on the design team?". '
+                        "The returned IDs can be passed to other tools (e.g. fetch_user_info) "
+                        "to get names, emails, or other details for each member."
                     ),
                 ),
                 *(

--- a/tiger_agent/agent/utils.py
+++ b/tiger_agent/agent/utils.py
@@ -41,6 +41,7 @@ from tiger_agent.slack.utils import (
     fetch_thread_messages,
     fetch_user_info,
     find_user_group,
+    get_user_ids_in_channel,
     get_user_ids_in_user_group,
 )
 from tiger_agent.tasks.types import Task
@@ -198,6 +199,16 @@ async def create_agent_and_context(
             client=hctx.app.client, user_group_id=group_id
         )
 
+    async def _get_user_ids_in_channel(channel_id: str) -> list[str] | str:
+        if not re.fullmatch(r"C[0-9A-Z]{10}", channel_id):
+            return (
+                f"Invalid channel id [{channel_id}]. Expected format: "
+                "'C' followed by 10 uppercase alphanumeric characters (e.g. 'C0123456789')."
+            )
+        return await get_user_ids_in_channel(
+            client=hctx.app.client, channel_id=channel_id
+        )
+
     # just a wrapper so we can pass the event in closure
     async def _get_tool_calls_for_event(
         lookback_hours: float = 24.0,
@@ -278,6 +289,27 @@ async def create_agent_and_context(
                         "not be found or the lookup failed.\n\n"
                         'Use when the user asks things like "who is in the @eng group?", '
                         '"list members of the on-call rotation", or "who is on the design team?". '
+                        "The returned IDs can be passed to other tools (e.g. fetch_user_info) "
+                        "to get names, emails, or other details for each member."
+                    ),
+                ),
+                Tool(
+                    _get_user_ids_in_channel,
+                    takes_ctx=False,
+                    name="get_user_ids_in_channel",
+                    description=(
+                        "List the Slack user IDs of every member of a Slack channel.\n\n"
+                        "The `channel_id` argument must be a Slack channel ID: the letter 'C' "
+                        "followed by 10 uppercase alphanumeric characters (e.g. 'C0123456789'). "
+                        "Channel names ('#general', 'general') and links are NOT accepted — "
+                        "if the user references a channel by name, resolve it to an ID first "
+                        "using the appropriate lookup tool.\n\n"
+                        "Returns a list of Slack user IDs, or an error string if the channel "
+                        "could not be read (e.g. the bot is not a member, the ID is invalid, "
+                        "or the channel is private and inaccessible). Results are automatically "
+                        "paginated across large channels.\n\n"
+                        'Use when the user asks things like "who is in this channel?", '
+                        '"list the members of C0123456789", or "get everyone in the channel". '
                         "The returned IDs can be passed to other tools (e.g. fetch_user_info) "
                         "to get names, emails, or other details for each member."
                     ),

--- a/tiger_agent/slack/types.py
+++ b/tiger_agent/slack/types.py
@@ -154,6 +154,34 @@ class TeamInfo(BaseModel):
     enterprise_name: str | None = None
 
 
+class UserGroupInfo(BaseModel):
+    """Pydantic model for a Slack user group (@handle).
+
+    Represents a Slack user group as returned by `usergroups.list`. Used to
+    resolve a human-readable group name/handle to its ID for downstream
+    membership lookups.
+
+    Attributes:
+        id: Unique user group identifier (e.g. 'S012345')
+        team_id: Team/workspace identifier
+        name: Display name of the group (e.g. 'Engineering')
+        handle: The @handle for the group (e.g. 'eng')
+        description: Optional description
+        is_usergroup: Always true for user groups
+        date_delete: Non-zero if the group has been disabled
+    """
+
+    model_config = {"extra": "allow"}
+
+    id: str
+    team_id: str | None = None
+    name: str
+    handle: str | None = None
+    description: str | None = None
+    is_usergroup: bool | None = None
+    date_delete: int | None = None
+
+
 @dataclass
 class SlackUrlParts:
     channel_id: str

--- a/tiger_agent/slack/utils.py
+++ b/tiger_agent/slack/utils.py
@@ -148,6 +148,27 @@ async def get_user_ids_in_user_group(
         return f"Could not retrieve users list {str(e)}"
 
 
+@logfire.instrument("get_user_ids_in_channel", extract_args=["channel_id"])
+async def get_user_ids_in_channel(
+    client: AsyncWebClient, channel_id: str
+) -> list[str] | str:
+    try:
+        members: list[str] = []
+        cursor: str | None = None
+        while True:
+            kwargs: dict[str, Any] = {"channel": channel_id, "limit": 1000}
+            if cursor:
+                kwargs["cursor"] = cursor
+            response = await client.conversations_members(**kwargs)
+            members.extend(response.data.get("members", []))
+            cursor = response.data.get("response_metadata", {}).get("next_cursor")
+            if not cursor:
+                break
+        return members
+    except SlackApiError as e:
+        return f"Could not retrieve channel members {str(e)}"
+
+
 @logfire.instrument("get_user_group_id", extract_args=["user_group_name"])
 async def find_user_group(
     client: AsyncWebClient, user_group_name: str

--- a/tiger_agent/slack/utils.py
+++ b/tiger_agent/slack/utils.py
@@ -60,6 +60,7 @@ from tiger_agent.slack.types import (
     SlackMessageEvent,
     SlackUrlParts,
     TeamInfo,
+    UserGroupInfo,
     UserInfo,
 )
 from tiger_agent.types import HarnessContext
@@ -136,6 +137,37 @@ async def add_reaction(client: AsyncWebClient, channel: str, ts: str, emoji: str
         pass
 
 
+@logfire.instrument("get_users_in_user_group", extract_args=["user_group_id"])
+async def get_user_ids_in_user_group(
+    client: AsyncWebClient, user_group_id: str
+) -> list[str] | str:
+    try:
+        users = await client.usergroups_users_list(usergroup=user_group_id)
+        return users.data["users"]
+    except SlackApiError as e:
+        return f"Could not retrieve users list {str(e)}"
+
+
+@logfire.instrument("get_user_group_id", extract_args=["user_group_name"])
+async def find_user_group(
+    client: AsyncWebClient, user_group_name: str
+) -> UserGroupInfo | None:
+    try:
+        response = await client.usergroups_list()
+        groups = [UserGroupInfo(**g) for g in response.get("usergroups", [])]
+        needle = user_group_name.lower().lstrip("@")
+        for group in groups:
+            if group.date_delete:
+                continue
+            if group.name.lower() == needle or (
+                group.handle and group.handle.lower() == needle
+            ):
+                return group
+        return None
+    except SlackApiError as e:
+        return f"Could not retrieve user group {str(e)}"
+
+
 @logfire.instrument("remove_reaction", extract_args=["channel", "ts", "emoji"])
 async def remove_reaction(client: AsyncWebClient, channel: str, ts: str, emoji: str):
     """Remove an emoji reaction from a Slack message.
@@ -172,6 +204,7 @@ async def fetch_user_info(client: AsyncWebClient, user_id: str) -> UserInfo | No
     """
     try:
         resp = await client.users_info(user=user_id, include_locale=True)
+
         assert isinstance(resp.data, dict)
         assert resp.data["ok"]
         return UserInfo(**(resp.data["user"]))


### PR DESCRIPTION
## What
This adds tools to the agent to be able to fetch users that are in a user group or a channel. 

Note: eon is using `channel:read`, so we will only get public channel/group info. If we wanted to see private, we would use `groups:read`

## Why
Is useful functionality.