### PR TITLE
[AGE-568] do not filter non email cases

### DIFF
--- a/tiger_agent/listeners/salesforce.py
+++ b/tiger_agent/listeners/salesforce.py
@@ -160,7 +160,7 @@ class SalesforceListener(Listener):
             logfire.info("Ignoring case event as owner has not changed")
             return
 
-        full_case_data = self._salesforce_client.Case.get(case.Id)
+        full_case_data = CaseData(**self._salesforce_client.Case.get(case.Id))
 
         await insert_event(
             pool=self._pool,
@@ -182,7 +182,7 @@ class SalesforceListener(Listener):
             logfire.info("Ignoring case")
             return
 
-        full_case_data = self._salesforce_client.Case.get(case.Id)
+        full_case_data = CaseData(**self._salesforce_client.Case.get(case.Id))
 
         await insert_event(
             pool=self._pool,

--- a/tiger_agent/salesforce/types.py
+++ b/tiger_agent/salesforce/types.py
@@ -35,6 +35,7 @@ class CaseData(BaseModel):
     ContactEmail: str | None = None
     Customer_Slack_Thread__c: str | None = None
     Subject: str | None = None
+    Origin: str | None = None
     Description: str | None = None
     Owner: SalesforceUser | None = None
     Status: str | None = None

--- a/tiger_agent/tasks/handlers.py
+++ b/tiger_agent/tasks/handlers.py
@@ -366,6 +366,10 @@ class SalesforceCaseCreatedHandler(TaskHandler):
         if not SALESFORCE_ENABLE_SPAM_FILTERING:
             return
 
+        # at this time we only care about filtering email messages
+        if task.event.case.Origin.lower() != "email":
+            return
+
         agent_and_ctx = await create_agent_and_context(
             hctx=hctx,
             task=task,


### PR DESCRIPTION
## What
Skip the spam detection on cases that do not originate from email.

## Why
So that we do not do detection on test cases, plus it doesn't really make sense to get spam from the console.