### PR TITLE
[AGE-569] Summarize new case notification

### DIFF
--- a/tiger_agent/agent/types.py
+++ b/tiger_agent/agent/types.py
@@ -67,14 +67,17 @@ class AgentResponseContext(BaseModel):
             self.local_time = self.task.event_ts.astimezone(ZoneInfo(self.user.tz))
 
 
-class AgentSalesforceResponse(BaseModel):
+class CaseSummary(BaseModel):
+    short_description: str = Field(
+        description="A brief 1-2 sentence summary of the support case issue."
+    )
+
+
+class AgentSalesforceResponse(CaseSummary):
     """Structured response for Salesforce case events."""
 
     is_spam: bool
     message: str
-    short_description_of_case: str = Field(
-        description="A brief 1-2 sentence summary of the support case issue."
-    )
     case_owner_slack_user_id: str | None = Field(
         default=None,
         description="The Slack user ID of the case owner (e.g. 'U012AB3CD'). Null if the Slack user ID cannot be determined for the case owner.",

--- a/tiger_agent/agent/utils.py
+++ b/tiger_agent/agent/utils.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
 
+import logfire
 from pydantic_ai import Agent, BinaryContent, Tool
 from pydantic_ai.messages import UserContent
 from pydantic_ai.toolsets.abstract import AbstractToolset
@@ -14,6 +15,7 @@ from tiger_agent.agent.tiger_agent import TigerAgent
 from tiger_agent.agent.types import (
     AgentResponseContext,
     AgentSalesforceResponse,
+    CaseSummary,
     ExtraContextDict,
 )
 from tiger_agent.db.utils import (
@@ -51,6 +53,24 @@ from tiger_agent.utils import (
     pretty_print_models,
     wrap_mcp_servers_with_exception_handling,
 )
+
+
+CASE_SUMMARY_MODEL = "anthropic:claude-sonnet-4-6"
+
+
+@logfire.instrument("summarize_new_case", extract_args=False)
+async def summarize_new_case(subject: str, description: str) -> str:
+    agent = Agent(
+        model=CASE_SUMMARY_MODEL,
+        output_type=CaseSummary,
+        system_prompt=(
+            "You summarize customer-submitted support case descriptions into a brief, "
+            "neutral 1-2 sentence summary of the issue. Do not add speculation, "
+            "greetings, or next steps."
+        ),
+    )
+    result = await agent.run(f"Subject: {subject}\n\nDescription: {description}")
+    return result.output.short_description
 
 
 def _build_toolset(mcp_config: McpConfig) -> AbstractToolset:

--- a/tiger_agent/agent/utils.py
+++ b/tiger_agent/agent/utils.py
@@ -54,7 +54,6 @@ from tiger_agent.utils import (
     wrap_mcp_servers_with_exception_handling,
 )
 
-
 CASE_SUMMARY_MODEL = "anthropic:claude-sonnet-4-6"
 
 

--- a/tiger_agent/slack/utils.py
+++ b/tiger_agent/slack/utils.py
@@ -1062,6 +1062,7 @@ async def send_new_salesforce_case_workflow_form(
                     "type": "plain_text",
                     "text": "Detailed description of the issue",
                 },
+                "max_length": 30000,
             },
         },
         *([service_block] if service_block else []),

--- a/tiger_agent/tasks/handlers.py
+++ b/tiger_agent/tasks/handlers.py
@@ -15,7 +15,7 @@ from htmlslacker import HTMLSlacker
 from pydantic_ai import Agent, Tool, UsageLimitExceeded, UsageLimits
 
 from tiger_agent.agent.tiger_agent import TigerAgent
-from tiger_agent.agent.utils import create_agent_and_context
+from tiger_agent.agent.utils import create_agent_and_context, summarize_new_case
 from tiger_agent.db.utils import (
     add_salesforce_case_thread,
     get_salesforce_account_id_for_channel,
@@ -287,7 +287,7 @@ class SalesforceAssignmentChangedHandler(TaskHandler):
             client=hctx.app.client,
             channel=SALESFORCE_CASE_CHANNEL,
             thread_ts=None,
-            text=f"*New Case* <{create_case_url(event.case.Id)}|{event.case.CaseNumber}> - _{event.case.Subject}_{f', assigned to {get_handle_link(case_owner_user_id)}' if case_owner_user_id else ''}:thread: \n```\n{response.output.short_description_of_case}\n```",
+            text=f"*New Case* <{create_case_url(event.case.Id)}|{event.case.CaseNumber}> - _{event.case.Subject}_{f', assigned to {get_handle_link(case_owner_user_id)}' if case_owner_user_id else ''}:thread: \n```\n{response.output.short_description}\n```",
         )
 
         message_to_link_to = SlackMessage(
@@ -425,7 +425,7 @@ class SalesforceCaseCreatedHandler(TaskHandler):
         add_internal_case_post(
             salesforce_client=hctx.salesforce_client,
             case_id=event.case.Id,
-            body=response.output.short_description_of_case,
+            body=response.output.short_description,
         )
         request_feedback(
             hctx.app.client,
@@ -509,6 +509,10 @@ class SalesforceCreateCaseHandler(TaskHandler):
             service_id=event.service_id,
             origin="Slack",
         )
+        subject = new_case.Subject or ""
+        short_description = await summarize_new_case(
+            subject=subject, description=new_case.Description or ""
+        )
         response = await post_response(
             client=hctx.app.client,
             channel=channel_to_respond,
@@ -518,7 +522,7 @@ class SalesforceCreateCaseHandler(TaskHandler):
                     "*Support Case Created*",
                     f"_Submitter:_ {get_handle_link(event.user)}",
                     f"_Case Number:_ `{new_case.CaseNumber}`",
-                    f"_Subject:_ `{new_case.Subject}`",
+                    f"_Subject:_ `{subject[0:1000]}`",
                     *(
                         [f"_Project Id:_: `{new_case.Cloud_Project_ID__c}`"]
                         if new_case.Cloud_Project_ID__c
@@ -530,7 +534,7 @@ class SalesforceCreateCaseHandler(TaskHandler):
                         else []
                     ),
                     "_Description:_",
-                    add_quote_block(new_case.Description),
+                    add_quote_block(short_description),
                 ]
             ),
             use_mrkdwn=True,


### PR DESCRIPTION
## What
Adds a simple LLM summary for description of a new Salesforce case created via Slack. This summary replaces the full summary. Also, this limits the input of description to 30k characters, well within Salesforce case description limit of 32k characters.

## Why
Slack's post message is limited to 2000 characters. If a case's description is super lengthy, we cannot post the thread for the case.

https://iobeam.slack.com/archives/C09AF06P37B/p1787068754001809?thread_ts=1787065277.224479&cid=C09AF06P37B