### PR TITLE
[AGE-569] Rollback limit on block

### DIFF
--- a/tiger_agent/slack/utils.py
+++ b/tiger_agent/slack/utils.py
@@ -1062,7 +1062,6 @@ async def send_new_salesforce_case_workflow_form(
                     "type": "plain_text",
                     "text": "Detailed description of the issue",
                 },
-                "max_length": 30000,
             },
         },
         *([service_block] if service_block else []),


### PR DESCRIPTION
## What
Rollback part of [PR](https://github.com/timescale/tiger-agents-for-work/pull/244) that adds a limit on the description input.

## Why
It's invalud