### PR TITLE
[AGE-579] Create a new Slack thread for Salesforce cases created

### DIFF
--- a/tiger_agent/agent/utils.py
+++ b/tiger_agent/agent/utils.py
@@ -36,7 +36,7 @@ from tiger_agent.utils import (
     wrap_mcp_servers_with_exception_handling,
 )
 
-CASE_SUMMARY_MODEL = "openrouter:anthropic/claude-sonnet-4-6"
+CASE_SUMMARY_MODEL = "openrouter:anthropic/claude-sonnet-4-5"
 
 
 @logfire.instrument("summarize_new_case", extract_args=False)

--- a/tiger_agent/agent/utils.py
+++ b/tiger_agent/agent/utils.py
@@ -36,7 +36,7 @@ from tiger_agent.utils import (
     wrap_mcp_servers_with_exception_handling,
 )
 
-CASE_SUMMARY_MODEL = "anthropic:claude-sonnet-4-6"
+CASE_SUMMARY_MODEL = "openrouter:anthropic/claude-sonnet-4-6"
 
 
 @logfire.instrument("summarize_new_case", extract_args=False)

--- a/tiger_agent/db/utils.py
+++ b/tiger_agent/db/utils.py
@@ -391,6 +391,20 @@ async def get_salesforce_account_id_for_channel(
         return row[0] if row else None
 
 
+async def get_slack_channel_for_salesforce_account_id(
+    pool: AsyncConnectionPool, account_id: str
+) -> str | None:
+    async with pool.connection() as con:
+        # at present, it is possible that at an account be linked to several channels as channel_id is the PK,
+        # but, in practice, this should never happen
+        result = await con.execute(
+            "SELECT channel_id FROM agent.customer_channel_salesforce_link WHERE salesforce_account_id = %s LIMIT 1",
+            (account_id,),
+        )
+        row = await result.fetchone()
+        return row[0] if row else None
+
+
 async def upsert_salesforce_account_id_for_channel(
     pool: AsyncConnectionPool, channel_id: str, salesforce_account_id: str
 ) -> None:
@@ -623,6 +637,8 @@ async def toggle_user_defined_rule(
                SET enabled = %s
                WHERE id = %s
                {"AND owner_slack_id = %s" if should_filter_on_user else ""}""",
-            (enabled, rule_id, owner_slack_id) if should_filter_on_user else (enabled, rule_id),
+            (enabled, rule_id, owner_slack_id)
+            if should_filter_on_user
+            else (enabled, rule_id),
         )
         return result.rowcount > 0

--- a/tiger_agent/salesforce/constants.py
+++ b/tiger_agent/salesforce/constants.py
@@ -7,6 +7,7 @@ CASE_STATUS_FIELD = "Status"
 DEV_HELP_LINKS_FIELD = "Dev_Help_Links__c"
 
 CASE_FIELDS = [
+    "AccountId",
     CASE_ID_FIELD,
     "CaseNumber",
     CASE_OWNER_ID_FIELD,
@@ -19,6 +20,8 @@ CASE_FIELDS = [
     "ContactEmail",
     "Severity__c",
     "Subject",
+    "SuppliedName",
+    "SuppliedEmail",
     "Status",
     "Priority",
     "CreatedDate",

--- a/tiger_agent/salesforce/types.py
+++ b/tiger_agent/salesforce/types.py
@@ -29,13 +29,16 @@ class CaseData(BaseModel):
 
     model_config = {"extra": "allow"}
 
+    AccountId: str
     Id: str
     CaseNumber: str | None = None
     Cloud_Impact__c: str | None = None
     ContactEmail: str | None = None
+    SuppliedName: str | None = None
+    SuppliedEmail: str | None = None
     Customer_Slack_Thread__c: str | None = None
     Subject: str | None = None
-    Origin: str | None = None
+    Origin: str = ""
     Description: str | None = None
     Owner: SalesforceUser | None = None
     Status: str | None = None

--- a/tiger_agent/salesforce/types.py
+++ b/tiger_agent/salesforce/types.py
@@ -38,7 +38,7 @@ class CaseData(BaseModel):
     SuppliedEmail: str | None = None
     Customer_Slack_Thread__c: str | None = None
     Subject: str | None = None
-    Origin: str = ""
+    Origin: str | None = None
     Description: str | None = None
     Owner: SalesforceUser | None = None
     Status: str | None = None

--- a/tiger_agent/tasks/handlers/salesforce_case_created.py
+++ b/tiger_agent/tasks/handlers/salesforce_case_created.py
@@ -1,11 +1,16 @@
 import logfire
 
 from tiger_agent.agent.tiger_agent import TigerAgent
+from tiger_agent.db.utils import get_slack_channel_for_salesforce_account_id
 from tiger_agent.salesforce.constants import (
     SALESFORCE_ENABLE_SPAM_FILTERING,
 )
+from tiger_agent.salesforce.types import SalesforceCaseCreatedEvent
 from tiger_agent.tasks.handlers.base import TaskHandler
-from tiger_agent.tasks.handlers.utils import detect_spam_case
+from tiger_agent.tasks.handlers.utils import (
+    create_slack_thread_for_case,
+    detect_spam_case,
+)
 from tiger_agent.tasks.types import Task
 from tiger_agent.types import HarnessContext
 
@@ -24,7 +29,25 @@ class SalesforceCaseCreatedHandler(TaskHandler):
 
     @logfire.instrument("SalesforceCaseCreatedHandler.handle", extract_args=False)
     async def handle(self, task: Task) -> None:
-        if not SALESFORCE_ENABLE_SPAM_FILTERING:
-            return
+        event: SalesforceCaseCreatedEvent = task.event
+        if event.case.Origin.lower() != "slack":
+            channel_id_for_account = await get_slack_channel_for_salesforce_account_id(
+                pool=self._hctx.pool, account_id=event.case.AccountId
+            )
 
-        await detect_spam_case(hctx=self._hctx, task=task, agent=self._agent)
+            if channel_id_for_account:
+                logfire.info(
+                    "New case created for an account linked to Slack channel",
+                    extra={
+                        "channel_id_for_account": channel_id_for_account,
+                        "case": event.case,
+                    },
+                )
+                await create_slack_thread_for_case(
+                    hctx=self._hctx, case=event.case, channel=channel_id_for_account
+                )
+
+                return
+
+        if SALESFORCE_ENABLE_SPAM_FILTERING:
+            await detect_spam_case(hctx=self._hctx, task=task, agent=self._agent)

--- a/tiger_agent/tasks/handlers/salesforce_case_created.py
+++ b/tiger_agent/tasks/handlers/salesforce_case_created.py
@@ -30,7 +30,7 @@ class SalesforceCaseCreatedHandler(TaskHandler):
     @logfire.instrument("SalesforceCaseCreatedHandler.handle", extract_args=False)
     async def handle(self, task: Task) -> None:
         event: SalesforceCaseCreatedEvent = task.event
-        if event.case.Origin.lower() != "slack":
+        if (event.case.Origin or "").lower() != "slack":
             channel_id_for_account = await get_slack_channel_for_salesforce_account_id(
                 pool=self._hctx.pool, account_id=event.case.AccountId
             )

--- a/tiger_agent/tasks/handlers/salesforce_case_created.py
+++ b/tiger_agent/tasks/handlers/salesforce_case_created.py
@@ -1,21 +1,11 @@
 import logfire
 
 from tiger_agent.agent.tiger_agent import TigerAgent
-from tiger_agent.agent.utils import create_agent_and_context
 from tiger_agent.salesforce.constants import (
-    SALESFORCE_CASE_CHANNEL,
     SALESFORCE_ENABLE_SPAM_FILTERING,
-    SALESFORCE_SLACK_THREAD_FIELD,
 )
-from tiger_agent.salesforce.types import SalesforceCaseCreatedEvent
-from tiger_agent.salesforce.utils import (
-    add_internal_case_post,
-    create_case_url,
-    update_case,
-)
-from tiger_agent.slack.types import SlackMessage
-from tiger_agent.slack.utils import post_response, request_feedback
-from tiger_agent.tasks.handlers.base import AGENT_USAGE_LIMITS, TaskHandler
+from tiger_agent.tasks.handlers.base import TaskHandler
+from tiger_agent.tasks.handlers.utils import detect_spam_case
 from tiger_agent.tasks.types import Task
 from tiger_agent.types import HarnessContext
 
@@ -34,81 +24,7 @@ class SalesforceCaseCreatedHandler(TaskHandler):
 
     @logfire.instrument("SalesforceCaseCreatedHandler.handle", extract_args=False)
     async def handle(self, task: Task) -> None:
-        hctx = self._hctx
-        event: SalesforceCaseCreatedEvent = task.event
-
         if not SALESFORCE_ENABLE_SPAM_FILTERING:
             return
 
-        # at this time we only care about filtering email messages
-        if task.event.case.Origin.lower() != "email":
-            return
-
-        agent_and_ctx = await create_agent_and_context(
-            hctx=hctx,
-            task=task,
-            agent=self._agent,
-            channel_to_respond=SALESFORCE_CASE_CHANNEL,
-        )
-
-        response = await agent_and_ctx.agent.run(
-            user_prompt=agent_and_ctx.user_prompt,
-            deps=agent_and_ctx.ctx,
-            usage_limits=AGENT_USAGE_LIMITS,
-        )
-
-        if not response.output.is_spam:
-            return
-
-        logfire.info(
-            "Salesforce case identified as spam",
-            extra={"filtering_enabled": SALESFORCE_ENABLE_SPAM_FILTERING},
-        )
-
-        original_message = await post_response(
-            client=hctx.app.client,
-            channel=SALESFORCE_CASE_CHANNEL,
-            thread_ts=None,
-            text=f"*Spam Detected* <{create_case_url(event.case.Id)}|{event.case.CaseNumber}> - _{event.case.Subject}_",
-        )
-
-        message_to_link_to = SlackMessage(
-            channel_id=SALESFORCE_CASE_CHANNEL,
-            ts=original_message.data.get("ts"),
-            text=response.output.message,
-            thread_ts=None,
-        )
-
-        if message_to_link_to and SALESFORCE_SLACK_THREAD_FIELD:
-            result = await hctx.app.client.chat_getPermalink(
-                channel=message_to_link_to.channel_id,
-                message_ts=message_to_link_to.ts,
-            )
-            permalink = result.data.get("permalink")
-            update_case(
-                hctx.salesforce_client,
-                event.case.Id,
-                {SALESFORCE_SLACK_THREAD_FIELD: permalink},
-            )
-
-            logfire.info(
-                "Updated Salesforce case to include the thread link",
-                extra={"permalink": permalink},
-            )
-
-        add_internal_case_post(
-            salesforce_client=hctx.salesforce_client,
-            case_id=event.case.Id,
-            body=response.output.short_description,
-        )
-        request_feedback(
-            hctx.app.client,
-            channel=message_to_link_to.channel_id,
-            thread_ts=message_to_link_to.ts,
-        )
-
-        update_case(
-            hctx.salesforce_client,
-            event.case.Id,
-            {"Status": "Spam", "Type": "Spam"},
-        )
+        await detect_spam_case(hctx=self._hctx, task=task, agent=self._agent)

--- a/tiger_agent/tasks/handlers/salesforce_create_case.py
+++ b/tiger_agent/tasks/handlers/salesforce_create_case.py
@@ -1,15 +1,13 @@
 import logfire
 
-from tiger_agent.agent.utils import summarize_new_case
 from tiger_agent.db.utils import (
-    add_salesforce_case_thread,
     get_salesforce_account_id_for_channel,
 )
-from tiger_agent.salesforce.constants import SALESFORCE_SLACK_CUSTOMER_THREAD_FIELD
 from tiger_agent.salesforce.types import SalesforceCreateNewCaseEvent
-from tiger_agent.salesforce.utils import create_case, update_case
-from tiger_agent.slack.utils import add_quote_block, get_handle_link, post_response
+from tiger_agent.salesforce.utils import create_case
+from tiger_agent.slack.utils import get_handle_link
 from tiger_agent.tasks.handlers.base import TaskHandler
+from tiger_agent.tasks.handlers.utils import create_slack_thread_for_case
 from tiger_agent.tasks.types import Task
 
 
@@ -46,69 +44,10 @@ class SalesforceCreateCaseHandler(TaskHandler):
             service_id=event.service_id,
             origin="Slack",
         )
-        subject = new_case.Subject or ""
-        short_description = await summarize_new_case(
-            subject=subject, description=new_case.Description or ""
-        )
-        response = await post_response(
-            client=hctx.app.client,
+
+        await create_slack_thread_for_case(
+            hctx=hctx,
+            case=new_case,
             channel=channel_to_respond,
-            thread_ts=None,
-            text="\n".join(
-                [
-                    "*Support Case Created*",
-                    f"_Submitter:_ {get_handle_link(event.user)}",
-                    f"_Case Number:_ `{new_case.CaseNumber}`",
-                    f"_Subject:_ `{subject[0:1000]}`",
-                    *(
-                        [f"_Project Id:_: `{new_case.Cloud_Project_ID__c}`"]
-                        if new_case.Cloud_Project_ID__c
-                        else []
-                    ),
-                    *(
-                        [f"_Service Id:_: `{new_case.Cloud_Service_ID__c}`"]
-                        if new_case.Cloud_Service_ID__c
-                        else []
-                    ),
-                    "_Description:_",
-                    add_quote_block(short_description),
-                ]
-            ),
-            use_mrkdwn=True,
-        )
-
-        new_case_thread_ts = response.data.get("ts", None)
-        if not new_case_thread_ts:
-            raise Exception(
-                "Could not create a thread for the customer-created Salesforce case"
-            )
-
-        await add_salesforce_case_thread(
-            hctx.pool,
-            thread_ts=new_case_thread_ts,
-            channel_id=channel_to_respond,
-            case_id=new_case.Id,
-        )
-
-        if not SALESFORCE_SLACK_CUSTOMER_THREAD_FIELD:
-            logfire.error(
-                "SALESFORCE_SLACK_CUSTOMER_THREAD_FIELD not specified, skipping"
-            )
-            return
-
-        result = await hctx.app.client.chat_getPermalink(
-            channel=channel_to_respond,
-            message_ts=new_case_thread_ts,
-        )
-        permalink = result.data.get("permalink")
-
-        update_case(
-            hctx.salesforce_client,
-            new_case.Id,
-            {SALESFORCE_SLACK_CUSTOMER_THREAD_FIELD: permalink},
-        )
-
-        logfire.info(
-            "Updated Salesforce case to include the customer thread link",
-            extra={"permalink": permalink},
+            submitter=get_handle_link(event.user),
         )

--- a/tiger_agent/tasks/handlers/utils.py
+++ b/tiger_agent/tasks/handlers/utils.py
@@ -1,0 +1,81 @@
+import logfire
+
+from tiger_agent.agent.utils import summarize_new_case
+from tiger_agent.db.utils import (
+    add_salesforce_case_thread,
+)
+from tiger_agent.salesforce.constants import SALESFORCE_SLACK_CUSTOMER_THREAD_FIELD
+from tiger_agent.salesforce.types import CaseData
+from tiger_agent.salesforce.utils import update_case
+from tiger_agent.slack.utils import add_quote_block, post_response
+from tiger_agent.types import HarnessContext
+
+
+async def create_slack_thread_for_case(
+    hctx: HarnessContext, case: CaseData, channel: str, submitter: str | None = None
+) -> None:
+    subject = case.Subject or ""
+    short_description = await summarize_new_case(
+        subject=subject, description=case.Description or ""
+    )
+    submitter = submitter or case.ContactEmail
+    response = await post_response(
+        client=hctx.app.client,
+        channel=channel,
+        thread_ts=None,
+        text="\n".join(
+            [
+                "*Support Case Created*",
+                *([f"_Submitter:_ {submitter}"] if submitter else []),
+                f"_Case Number:_ `{case.CaseNumber}`",
+                f"_Subject:_ `{subject[0:1000]}`",
+                *(
+                    [f"_Project Id:_: `{case.Cloud_Project_ID__c}`"]
+                    if case.Cloud_Project_ID__c
+                    else []
+                ),
+                *(
+                    [f"_Service Id:_: `{case.Cloud_Service_ID__c}`"]
+                    if case.Cloud_Service_ID__c
+                    else []
+                ),
+                "_Description:_",
+                add_quote_block(short_description),
+            ]
+        ),
+        use_mrkdwn=True,
+    )
+
+    new_case_thread_ts = response.data.get("ts", None)
+    if not new_case_thread_ts:
+        raise Exception(
+            "Could not create a thread for the customer-created Salesforce case"
+        )
+
+    await add_salesforce_case_thread(
+        hctx.pool,
+        thread_ts=new_case_thread_ts,
+        channel_id=channel,
+        case_id=case.Id,
+    )
+
+    if not SALESFORCE_SLACK_CUSTOMER_THREAD_FIELD:
+        logfire.error("SALESFORCE_SLACK_CUSTOMER_THREAD_FIELD not specified, skipping")
+        return
+
+    result = await hctx.app.client.chat_getPermalink(
+        channel=channel,
+        message_ts=new_case_thread_ts,
+    )
+    permalink = result.data.get("permalink")
+
+    update_case(
+        hctx.salesforce_client,
+        case.Id,
+        {SALESFORCE_SLACK_CUSTOMER_THREAD_FIELD: permalink},
+    )
+
+    logfire.info(
+        "Updated Salesforce case to include the customer thread link",
+        extra={"permalink": permalink},
+    )

--- a/tiger_agent/tasks/handlers/utils.py
+++ b/tiger_agent/tasks/handlers/utils.py
@@ -99,7 +99,7 @@ async def detect_spam_case(hctx: HarnessContext, task: Task, agent: TigerAgent) 
     event: SalesforceCaseCreatedEvent = task.event
 
     # at this time we only care about filtering email messages
-    if event.case.Origin.lower() != "email":
+    if (event.case.Origin or "").lower() != "email":
         return
 
     agent_and_ctx = await create_agent_and_context(

--- a/tiger_agent/tasks/handlers/utils.py
+++ b/tiger_agent/tasks/handlers/utils.py
@@ -30,7 +30,9 @@ async def create_slack_thread_for_case(
     short_description = await summarize_new_case(
         subject=subject, description=case.Description or ""
     )
-    submitter = submitter or case.ContactEmail
+    submitter = (
+        submitter or case.SuppliedName or case.SuppliedEmail or case.ContactEmail
+    )
     response = await post_response(
         client=hctx.app.client,
         channel=channel,

--- a/tiger_agent/tasks/handlers/utils.py
+++ b/tiger_agent/tasks/handlers/utils.py
@@ -1,13 +1,25 @@
 import logfire
 
-from tiger_agent.agent.utils import summarize_new_case
+from tiger_agent.agent.tiger_agent import TigerAgent
+from tiger_agent.agent.utils import create_agent_and_context, summarize_new_case
 from tiger_agent.db.utils import (
     add_salesforce_case_thread,
 )
-from tiger_agent.salesforce.constants import SALESFORCE_SLACK_CUSTOMER_THREAD_FIELD
-from tiger_agent.salesforce.types import CaseData
-from tiger_agent.salesforce.utils import update_case
-from tiger_agent.slack.utils import add_quote_block, post_response
+from tiger_agent.salesforce.constants import (
+    SALESFORCE_CASE_CHANNEL,
+    SALESFORCE_SLACK_CUSTOMER_THREAD_FIELD,
+    SALESFORCE_SLACK_THREAD_FIELD,
+)
+from tiger_agent.salesforce.types import CaseData, SalesforceCaseCreatedEvent
+from tiger_agent.salesforce.utils import (
+    add_internal_case_post,
+    create_case_url,
+    update_case,
+)
+from tiger_agent.slack.types import SlackMessage
+from tiger_agent.slack.utils import add_quote_block, post_response, request_feedback
+from tiger_agent.tasks.handlers.base import AGENT_USAGE_LIMITS
+from tiger_agent.tasks.types import Task
 from tiger_agent.types import HarnessContext
 
 
@@ -78,4 +90,86 @@ async def create_slack_thread_for_case(
     logfire.info(
         "Updated Salesforce case to include the customer thread link",
         extra={"permalink": permalink},
+    )
+
+
+async def detect_spam_case(hctx: HarnessContext, task: Task, agent: TigerAgent) -> None:
+    event: SalesforceCaseCreatedEvent = task.event
+
+    # at this time we only care about filtering email messages
+    if event.case.Origin.lower() != "email":
+        return
+
+    agent_and_ctx = await create_agent_and_context(
+        hctx=hctx,
+        task=task,
+        agent=agent,
+        channel_to_respond=SALESFORCE_CASE_CHANNEL,
+    )
+
+    response = await agent_and_ctx.agent.run(
+        user_prompt=agent_and_ctx.user_prompt,
+        deps=agent_and_ctx.ctx,
+        usage_limits=AGENT_USAGE_LIMITS,
+    )
+
+    if not response.output.is_spam:
+        return
+
+    logfire.info(
+        "Salesforce case identified as spam",
+    )
+
+    original_message = await post_response(
+        client=hctx.app.client,
+        channel=SALESFORCE_CASE_CHANNEL,
+        thread_ts=None,
+        text=f"*Spam Detected* <{create_case_url(event.case.Id)}|{event.case.CaseNumber}> - _{event.case.Subject}_",
+    )
+
+    message_thread = original_message.data.get("ts")
+    if not message_thread:
+        raise Exception(
+            "Could not create a thread for the customer-created Salesforce case"
+        )
+
+    message_to_link_to = SlackMessage(
+        channel_id=SALESFORCE_CASE_CHANNEL,
+        ts=message_thread,
+        text=response.output.message,
+        thread_ts=None,
+    )
+
+    if SALESFORCE_SLACK_THREAD_FIELD:
+        result = await hctx.app.client.chat_getPermalink(
+            channel=message_to_link_to.channel_id,
+            message_ts=message_to_link_to.ts,
+        )
+        permalink = result.data.get("permalink")
+        update_case(
+            hctx.salesforce_client,
+            event.case.Id,
+            {SALESFORCE_SLACK_THREAD_FIELD: permalink},
+        )
+
+        logfire.info(
+            "Updated Salesforce case to include the thread link",
+            extra={"permalink": permalink},
+        )
+
+    add_internal_case_post(
+        salesforce_client=hctx.salesforce_client,
+        case_id=event.case.Id,
+        body=response.output.short_description,
+    )
+    request_feedback(
+        hctx.app.client,
+        channel=message_to_link_to.channel_id,
+        thread_ts=message_to_link_to.ts,
+    )
+
+    update_case(
+        hctx.salesforce_client,
+        event.case.Id,
+        {"Status": "Spam", "Type": "Spam"},
     )


### PR DESCRIPTION
## What
Given a customer has a Account->Slack Channel association created via Eon
When a customer creates a new Salesforce case from any source other than Slack (since that will already create the notification)
Then a new thread is created in the customer's Slack Channel


## Demo
https://iobeam.slack.com/archives/C09DL0P0XGS/p1787779212502769