### PR TITLE
[CHORE] add dependabot config for uv + github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "python:uv"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly grouped updates for the `uv` (Python) and `github-actions` ecosystems.
- All package bumps within each ecosystem are grouped into a single PR to reduce review overhead.
- Replaces the previous ad-hoc, security-only Dependabot behavior with a scheduled, bundled workflow.

## Test plan
- [ ] After merge, verify Dependabot runs against this config (Insights → Dependency graph → Dependabot).
- [ ] Confirm the next weekly run opens at most one grouped `uv` PR and one grouped `github-actions` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)