### PR TITLE
[CHORE] AccountId can be null

### DIFF
--- a/tiger_agent/salesforce/types.py
+++ b/tiger_agent/salesforce/types.py
@@ -29,7 +29,7 @@ class CaseData(BaseModel):
 
     model_config = {"extra": "allow"}
 
-    AccountId: str
+    AccountId: str | None = None
     Id: str
     CaseNumber: str | None = None
     Cloud_Impact__c: str | None = None

--- a/tiger_agent/tasks/handlers/salesforce_case_created.py
+++ b/tiger_agent/tasks/handlers/salesforce_case_created.py
@@ -30,7 +30,7 @@ class SalesforceCaseCreatedHandler(TaskHandler):
     @logfire.instrument("SalesforceCaseCreatedHandler.handle", extract_args=False)
     async def handle(self, task: Task) -> None:
         event: SalesforceCaseCreatedEvent = task.event
-        if (event.case.Origin or "").lower() != "slack":
+        if (event.case.Origin or "").lower() != "slack" and event.case.AccountId:
             channel_id_for_account = await get_slack_channel_for_salesforce_account_id(
                 pool=self._hctx.pool, account_id=event.case.AccountId
             )


### PR DESCRIPTION
## What
This allows `AccountId` to be null. This field was added in this [PR](https://github.com/timescale/tiger-agents-for-work/pull/252)

## Why
Because some cases have null account ids which causes a Pydantic Validation error