### PR TITLE
Fall back to post_response when a Slack event has no recipient user

### DIFF
--- a/tiger_agent/tasks/handlers/slack.py
+++ b/tiger_agent/tasks/handlers/slack.py
@@ -1,4 +1,5 @@
 import logfire
+from pydantic_ai.messages import PartDeltaEvent, PartStartEvent, TextPart, TextPartDelta
 
 from tiger_agent.agent.utils import create_agent_and_context
 from tiger_agent.db.utils import usage_limit_reached, user_ignored
@@ -60,26 +61,52 @@ class SlackTaskHandler(TaskHandler):
         )
         slack_stream = None
 
+        # events with no originating user (e.g. Slack Workflow / bot-posted
+        # mentions) have no recipient_user_id to stream to, so
+        # chat.startStream fails with "missing_recipient_user_id". Fall back
+        # to accumulating the response and posting it once via post_response.
+        can_stream = event.user is not None
+        response_text_parts: list[str] = []
+
         async with agent_and_ctx.agent.run_stream_events(
             user_prompt=agent_and_ctx.user_prompt,
             deps=agent_and_ctx.ctx,
             usage_limits=AGENT_USAGE_LIMITS,
         ) as stream_events:
             async for stream_event in stream_events:
-                slack_stream = await stream_response_to_mention(
-                    client=hctx.app.client,
-                    slack_stream=slack_stream,
-                    stream_event=stream_event,
-                    channel_id=event.channel,
-                    recipient_user_id=event.user,
-                    recipient_team_id=event.user_team or hctx.bot_info.team_id,
-                    ts=event.ts,
-                    thread_ts=event.thread_ts,
-                )
+                if can_stream:
+                    slack_stream = await stream_response_to_mention(
+                        client=hctx.app.client,
+                        slack_stream=slack_stream,
+                        stream_event=stream_event,
+                        channel_id=event.channel,
+                        recipient_user_id=event.user,
+                        recipient_team_id=event.user_team or hctx.bot_info.team_id,
+                        ts=event.ts,
+                        thread_ts=event.thread_ts,
+                    )
+                elif isinstance(stream_event, PartStartEvent) and isinstance(
+                    stream_event.part, TextPart
+                ):
+                    response_text_parts.append(stream_event.part.content or "")
+                elif isinstance(stream_event, PartDeltaEvent) and isinstance(
+                    stream_event.delta, TextPartDelta
+                ):
+                    response_text_parts.append(stream_event.delta.content_delta or "")
 
-        if slack_stream is not None and slack_stream._state != "completed":
-            rest = await slack_stream.stop()
-            logfire.info("ended", extra={"res": rest})
+        if can_stream:
+            if slack_stream is not None and slack_stream._state != "completed":
+                rest = await slack_stream.stop()
+                logfire.info("ended", extra={"res": rest})
+        else:
+            response_text = "".join(response_text_parts).strip()
+            if response_text:
+                await post_response(
+                    client=hctx.app.client,
+                    channel=event.channel,
+                    thread_ts=event.thread_ts or event.ts,
+                    text=response_text,
+                )
 
         await set_status(
             client=hctx.app.client,


### PR DESCRIPTION
## What
`SlackTaskHandler.handle` always streams responses via `chat.startStream` with `recipient_user_id=event.user`. When `event.user` is `None`, that call fails immediately with `missing_recipient_user_id`, and the never-opened stream keeps failing on every subsequent buffer flush/append.

This adds a fallback: when there's no recipient user, skip streaming entirely, accumulate the agent's text response, and post it once via `post_response` on the thread.

## Why
Traced via Logfire: events with no originating user are typically Slack Workflow / bot-posted `app_mentions` (`event.user is None`), e.g. a scheduled monthly report workflow mentioning the bot. These aren't flaky — they fail deterministically every time, cascading one root cause into ~10-15 error log entries per occurrence (`missing_recipient_user_id` -> repeated `Failed to flush stream buffer` / `append_message_to_stream` failures).

## Test plan
- [x] `ruff check` passes on the changed file
- [x] Module imports cleanly
- [x] Existing `tiger_agent/slack/utils_specs.py` suite still passes
- [ ] Manually verify a Slack Workflow-triggered mention (no `event.user`) now gets a normal threaded reply instead of erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)