### PR TITLE
[AGE-585] use dedicated lower-level agent for spam detection

### DIFF
--- a/tiger_agent/agent/constants.py
+++ b/tiger_agent/agent/constants.py
@@ -1,3 +1,25 @@
 import os
 
+from pydantic_ai import UsageLimits
+
 USER_DEFINED_EVENTS_ENABLED = os.environ.get("USER_DEFINED_EVENTS_ENABLED", False)
+
+# Condenses a newly created case into a one-line description for the Slack post.
+CASE_SUMMARY_MODEL = os.environ.get(
+    "CASE_SUMMARY_MODEL", "openrouter:anthropic/claude-sonnet-5"
+)
+
+# Spam triage. Deliberately not the cheapest available model: a false positive
+# sets Status/Type to Spam on a real customer's case, which nobody is watching
+# for. The whole path costs a couple of dollars a year, so the saving from a
+# smaller model does not justify the extra misclassification risk.
+SPAM_DETECTION_MODEL = os.environ.get(
+    "SPAM_DETECTION_MODEL", "openrouter:anthropic/claude-sonnet-5"
+)
+
+# Spam triage reads the case text; it does not investigate it. A tool-free
+# agent keeps a junk case from costing a full investigation.
+SPAM_DETECTION_USAGE_LIMITS = UsageLimits(
+    request_limit=2,
+    output_tokens_limit=2_000,
+)

--- a/tiger_agent/agent/tiger_agent.py
+++ b/tiger_agent/agent/tiger_agent.py
@@ -39,6 +39,9 @@ USER_PROMPT_REGEX = r"^user_prompt.*\.md$"
 INVESTIGATOR_SYSTEM_PROMPT_REGEX = (
     r"^(investigator_system_prompt|shared_system_prompt).*\.md$"
 )
+# Deliberately excluded from SYSTEM_PROMPT_REGEX: spam triage runs as its own
+# small agent and must not inherit the main agent's instructions.
+SPAM_DETECTION_PROMPT_REGEX = r"^spam_detection_prompt.*\.md$"
 
 
 class TigerAgent:

--- a/tiger_agent/agent/types.py
+++ b/tiger_agent/agent/types.py
@@ -73,10 +73,31 @@ class CaseSummary(BaseModel):
     )
 
 
+class SpamAssessment(BaseModel):
+    """Verdict from the dedicated spam-detection agent.
+
+    Produced by a small, tool-free model so that triaging junk costs a fraction
+    of a full case investigation. See ``prompts/spam_detection_prompt.md``.
+    """
+
+    is_spam: bool = Field(
+        description="True only when the case is clearly spam. When in doubt, False."
+    )
+    reason: str = Field(
+        description="One or two sentences naming the evidence behind the verdict, recorded for auditing."
+    )
+    short_description: str = Field(
+        description="A brief 1-2 sentence neutral summary of what the case says."
+    )
+    message: str = Field(
+        default="",
+        description="Slack mrkdwn notification body. Populated only when is_spam is True.",
+    )
+
+
 class AgentSalesforceResponse(CaseSummary):
     """Structured response for Salesforce case events."""
 
-    is_spam: bool
     message: str
     case_owner_slack_user_id: str | None = Field(
         default=None,

--- a/tiger_agent/agent/utils.py
+++ b/tiger_agent/agent/utils.py
@@ -11,17 +11,28 @@ from pydantic_ai.toolsets.abstract import AbstractToolset
 from pydantic_ai_harness import SubAgent, SubAgents
 from pydantic_ai_summarization import ContextManagerCapability
 
-from tiger_agent.agent.tiger_agent import INVESTIGATOR_SYSTEM_PROMPT_REGEX, TigerAgent
+from tiger_agent.agent.constants import (
+    CASE_SUMMARY_MODEL,
+    SPAM_DETECTION_MODEL,
+    SPAM_DETECTION_USAGE_LIMITS,
+)
+from tiger_agent.agent.tiger_agent import (
+    INVESTIGATOR_SYSTEM_PROMPT_REGEX,
+    SPAM_DETECTION_PROMPT_REGEX,
+    TigerAgent,
+)
 from tiger_agent.agent.tools import create_tools
 from tiger_agent.agent.types import (
     AgentResponseContext,
     AgentSalesforceResponse,
     CaseSummary,
     ExtraContextDict,
+    SpamAssessment,
 )
 from tiger_agent.mcp.types import McpConfig
 from tiger_agent.mcp.utils import filter_mcp_servers
 from tiger_agent.salesforce.types import (
+    CaseData,
     SalesforceBaseEvent,
 )
 from tiger_agent.slack.utils import (
@@ -34,8 +45,6 @@ from tiger_agent.utils import (
     pretty_print_models,
     wrap_mcp_servers_with_exception_handling,
 )
-
-CASE_SUMMARY_MODEL = "openrouter:anthropic/claude-sonnet-5"
 
 # Only the settings matching the active model's provider prefix are read; the rest are
 # ignored, so it's safe to set both Anthropic's and OpenRouter's cache keys regardless of
@@ -62,6 +71,59 @@ async def summarize_new_case(subject: str, description: str) -> str:
     )
     result = await agent.run(f"Subject: {subject}\n\nDescription: {description}")
     return result.output.short_description
+
+
+@logfire.instrument("assess_case_for_spam", extract_args=False)
+async def assess_case_for_spam(
+    agent: TigerAgent,
+    ctx: AgentResponseContext,
+    case: CaseData,
+) -> SpamAssessment:
+    """Decide whether a newly created case is spam.
+
+    Deliberately does not go through ``create_agent_and_context``: spam triage
+    needs to read the case, not investigate it, so it runs on a small model with
+    no toolsets, no skills and no subagents. The prompt is rendered through the
+    normal template machinery so a downstream package can override it.
+    """
+    system_prompt = await agent.render_prompts(
+        regex=SPAM_DETECTION_PROMPT_REGEX, ctx=ctx, extra_ctx={}
+    )
+
+    spam_agent = Agent(
+        model=SPAM_DETECTION_MODEL,
+        model_settings=PROMPT_CACHE_MODEL_SETTINGS,
+        output_type=SpamAssessment,
+        system_prompt=system_prompt,
+    )
+
+    user_prompt = "\n".join(
+        [
+            "Assess the following Salesforce case.",
+            "",
+            f"Case Number: {case.CaseNumber or '(none)'}",
+            f"Subject: {case.Subject or '(none)'}",
+            f"Origin: {case.Origin or '(unknown)'}",
+            f"Supplied Name: {case.SuppliedName or '(none)'}",
+            f"Supplied Email: {case.SuppliedEmail or case.ContactEmail or '(none)'}",
+            f"Account Id: {case.AccountId or '(none)'}",
+            "",
+            "Description:",
+            case.Description or "(empty)",
+        ]
+    )
+
+    result = await spam_agent.run(
+        user_prompt=user_prompt,
+        usage_limits=SPAM_DETECTION_USAGE_LIMITS,
+    )
+    logfire.info(
+        "Spam assessment complete",
+        is_spam=result.output.is_spam,
+        reason=result.output.reason,
+        case_number=case.CaseNumber,
+    )
+    return result.output
 
 
 def _build_toolset(mcp_config: McpConfig) -> AbstractToolset:

--- a/tiger_agent/prompts/spam_detection_prompt.md
+++ b/tiger_agent/prompts/spam_detection_prompt.md
@@ -1,0 +1,44 @@
+You triage inbound Salesforce support cases for Tiger Data and decide whether a case is spam.
+
+You have no tools. Judge only from the case fields given to you. Do not speculate about
+information you were not shown, and do not ask for more.
+
+## What counts as spam
+
+A case is spam if any of the following clearly applies:
+
+- The subject or description is a vendor solicitation, marketing email, or sales pitch.
+- It is a phishing attempt, a scam, or a bulk-sent message that happens to have reached support.
+- The content is unrelated to Tiger Data's products or to a technical support issue.
+- It is an unauthenticated, vague vulnerability-disclosure or bug-bounty solicitation with no
+  specific, reproducible finding.
+
+Treat a missing account id or a free-email sender domain as weak supporting evidence only.
+Plenty of legitimate cases arrive that way, so never call a case spam on that basis alone.
+
+## What is not spam
+
+- Any genuine technical question, error report, or performance complaint, however brief,
+  vague, or poorly written.
+- Billing, account, and cancellation requests.
+- Automated alerts or monitoring notifications from a customer's own systems.
+- A case in a language other than English.
+
+When the evidence is mixed or you are unsure, answer `is_spam: false`. A real case wrongly
+filtered as spam is far more costly than a spam case that reaches an engineer.
+
+## Output
+
+Return:
+
+- `is_spam` — your verdict.
+- `reason` — one or two sentences naming the specific evidence behind the verdict. This is
+  recorded for auditing, so write it for both outcomes, not just for spam.
+- `short_description` — a brief, neutral one-to-two sentence summary of what the case
+  actually says. No speculation, greetings, or next steps.
+- `message` — the Slack notification body, in Slack mrkdwn (single asterisks for bold, not
+  double). Only used when `is_spam` is true; return an empty string otherwise. Format it as:
+
+```
+*Reason:* <one or two sentences explaining why this case is considered spam>
+```

--- a/tiger_agent/tasks/handlers/salesforce_assignment_changed.py
+++ b/tiger_agent/tasks/handlers/salesforce_assignment_changed.py
@@ -7,7 +7,6 @@ from tiger_agent.agent.utils import create_agent_and_context
 from tiger_agent.db.utils import upsert_feedback_request_reminder
 from tiger_agent.salesforce.constants import (
     SALESFORCE_CASE_CHANNEL,
-    SALESFORCE_ENABLE_SPAM_FILTERING,
     SALESFORCE_SLACK_THREAD_FIELD,
 )
 from tiger_agent.salesforce.types import SalesforceAssignmentChangedEvent
@@ -49,14 +48,6 @@ class SalesforceAssignmentChangedHandler(TaskHandler):
             usage_limits=AGENT_USAGE_LIMITS,
         )
         output = cast(AgentSalesforceResponse, response.output)
-
-        if output.is_spam:
-            logfire.info(
-                "Salesforce case identified as spam",
-                extra={"filtering_enabled": SALESFORCE_ENABLE_SPAM_FILTERING},
-            )
-            if SALESFORCE_ENABLE_SPAM_FILTERING:
-                return
 
         case_owner_user_id = output.case_owner_slack_user_id
 

--- a/tiger_agent/tasks/handlers/salesforce_case_created.py
+++ b/tiger_agent/tasks/handlers/salesforce_case_created.py
@@ -15,10 +15,13 @@ from tiger_agent.tasks.types import Task
 
 class SalesforceCaseCreatedHandler(TaskHandler):
     """
-    Runs the agent to determine if the case is spam.
-    We handle legitimate new cases with the SalesforceAssignmentChangedHandler
-    as, at that point we have a assignee and spam should have been filtered out
-    So this handler is strictly to detect spam cases
+    Determines whether a newly created case is spam.
+
+    Legitimate new cases are handled by SalesforceAssignmentChangedHandler once
+    an assignee exists, so this handler is strictly spam triage. It runs a small
+    tool-free agent (see ``assess_case_for_spam``) rather than the full Eon
+    agent -- deciding that an email is a vendor solicitation does not warrant a
+    case investigation.
     """
 
     EVENT_TYPES = [SalesforceCaseCreatedEvent]

--- a/tiger_agent/tasks/handlers/utils.py
+++ b/tiger_agent/tasks/handlers/utils.py
@@ -1,10 +1,8 @@
-from typing import cast
-
 import logfire
 
 from tiger_agent.agent.tiger_agent import TigerAgent
-from tiger_agent.agent.types import AgentSalesforceResponse
-from tiger_agent.agent.utils import create_agent_and_context, summarize_new_case
+from tiger_agent.agent.types import AgentResponseContext
+from tiger_agent.agent.utils import assess_case_for_spam, summarize_new_case
 from tiger_agent.db.utils import (
     add_salesforce_case_thread,
 )
@@ -21,7 +19,6 @@ from tiger_agent.salesforce.utils import (
 )
 from tiger_agent.slack.types import SlackMessage
 from tiger_agent.slack.utils import add_quote_block, post_response, request_feedback
-from tiger_agent.tasks.handlers.base import AGENT_USAGE_LIMITS
 from tiger_agent.tasks.types import Task
 from tiger_agent.types import HarnessContext
 
@@ -108,19 +105,15 @@ async def detect_spam_case(hctx: HarnessContext, task: Task, agent: TigerAgent) 
     if (event.case.Origin or "").lower() != "email":
         return
 
-    agent_and_ctx = await create_agent_and_context(
-        hctx=hctx,
-        task=task,
-        agent=agent,
-        channel_to_respond=SALESFORCE_CASE_CHANNEL,
-    )
+    if hctx.bot_info is None:
+        logfire.error("Cannot assess a case for spam without bot info, aborting")
+        return
 
-    response = await agent_and_ctx.agent.run(
-        user_prompt=agent_and_ctx.user_prompt,
-        deps=agent_and_ctx.ctx,
-        usage_limits=AGENT_USAGE_LIMITS,
+    output = await assess_case_for_spam(
+        agent=agent,
+        ctx=AgentResponseContext(task=task, mention=event, bot=hctx.bot_info),
+        case=event.case,
     )
-    output = cast(AgentSalesforceResponse, response.output)
 
     if not output.is_spam:
         return


### PR DESCRIPTION
## What
Replaces the `create_agent_and_context` usage (which uses opus in prod) for generating a spam detection agent for new Salesforce cases.

## Why
Opus is expensive and not needed for this task