### PR TITLE
Degrade gracefully instead of aborting at the usage limit

### DIFF
--- a/tiger_agent/agent/limits.py
+++ b/tiger_agent/agent/limits.py
@@ -1,0 +1,178 @@
+"""Run budgets and graceful degradation for agent runs.
+
+Three layers cooperate so that a long run winds down instead of dying:
+
+1. ``make_limit_warner()`` injects an escalating warning as the run approaches
+   its budget, so the model converges on an answer by itself.
+2. ``AGENT_USAGE_LIMITS`` is the hard backstop. It stops a genuine runaway.
+3. ``run_and_return_partial()`` catches that backstop and spends one tool-free call
+   turning the accumulated context into a partial answer, rather than losing
+   the whole run.
+
+This module deliberately imports nothing from ``tiger_agent`` so that both
+``tiger_agent.agent`` and ``tiger_agent.tasks`` can depend on it.
+"""
+
+from __future__ import annotations
+
+import logfire
+from pydantic_ai import UsageLimitExceeded, UsageLimits, capture_run_messages
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelRequestPart,
+    ModelResponse,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+from pydantic_ai_summarization import LimitWarnerCapability
+
+# Hard backstop. Unchanged from the original definition in tasks.handlers.base;
+# the warner below is what should normally end a long run.
+AGENT_MAX_REQUESTS = 150
+AGENT_MAX_OUTPUT_TOKENS = 40_000
+
+AGENT_USAGE_LIMITS = UsageLimits(
+    output_tokens_limit=AGENT_MAX_OUTPUT_TOKENS,
+    request_limit=AGENT_MAX_REQUESTS,
+)
+
+# Context ceiling the warner measures against. Matches the ``max_tokens`` given
+# to ContextManagerCapability so the two agree on what "full" means.
+AGENT_MAX_CONTEXT_TOKENS = 800_000
+
+# Advisory only -- nothing enforces this, it just gives the warner a cumulative
+# budget to count down against. Sized above the observed p75 for the most
+# expensive handler (SalesforceAssignmentChanged, p75 ~6.1M input tokens over a
+# 5 day sample) so routine work never sees a warning.
+AGENT_SOFT_TOTAL_TOKENS = 8_000_000
+
+# The fallback call makes exactly one tool-free request, so it needs a budget of
+# its own -- the run's original limits are already exhausted by definition.
+FINALIZE_USAGE_LIMITS = UsageLimits(
+    output_tokens_limit=AGENT_MAX_OUTPUT_TOKENS,
+    request_limit=2,
+)
+
+FINALIZE_PROMPT = (
+    "You have reached your research budget for this task and no tools are "
+    "available for the rest of this turn. Do not ask to continue and do not "
+    "request more information.\n\n"
+    "Produce your final answer now, in the required output format, using only "
+    "what you have already gathered. Where a section is incomplete, say plainly "
+    "what you were unable to determine and what you would have checked next, "
+    "rather than guessing or leaving it blank."
+)
+
+
+def make_limit_warner() -> LimitWarnerCapability:
+    """Warn the model as it approaches its run budget.
+
+    The warning arrives as a trailing user message, which models attend to far
+    more reliably than appended system text. Warnings begin at 70% of a limit
+    and become critical with three requests to spare, which gives the agent
+    room to stop searching and write its answer before anything is enforced.
+    """
+    return LimitWarnerCapability(
+        max_iterations=AGENT_MAX_REQUESTS,
+        max_context_tokens=AGENT_MAX_CONTEXT_TOKENS,
+        max_total_tokens=AGENT_SOFT_TOTAL_TOKENS,
+        warning_threshold=0.7,
+        critical_remaining_iterations=3,
+    )
+
+
+def _close_dangling_tool_calls(messages: list[ModelMessage]) -> list[ModelMessage]:
+    """Answer any tool calls the aborted run left outstanding.
+
+    A run cut short by a usage limit can end on a ``ModelResponse`` whose tool
+    calls never received results. Anthropic rejects a history containing a
+    ``tool_use`` with no matching ``tool_result``, so replaying it verbatim
+    would fail. Rather than truncating back to the last clean exchange -- which
+    would throw away the very context we are trying to preserve -- synthesise a
+    cancellation result for each unanswered call.
+    """
+    if not messages:
+        return []
+
+    answered: set[str] = {
+        part.tool_call_id
+        for message in messages
+        if isinstance(message, ModelRequest)
+        for part in message.parts
+        if isinstance(part, ToolReturnPart)
+    }
+
+    outstanding = [
+        part
+        for message in messages
+        if isinstance(message, ModelResponse)
+        for part in message.parts
+        if isinstance(part, ToolCallPart) and part.tool_call_id not in answered
+    ]
+
+    if not outstanding:
+        return list(messages)
+
+    logfire.info(
+        "Closing dangling tool calls before finalizing",
+        outstanding=len(outstanding),
+        tool_names=sorted({part.tool_name for part in outstanding}),
+    )
+
+    cancellations: list[ModelRequestPart] = [
+        ToolReturnPart(
+            tool_name=part.tool_name,
+            content="Cancelled: the run's budget was exhausted before this tool ran.",
+            tool_call_id=part.tool_call_id,
+        )
+        for part in outstanding
+    ]
+
+    return [*messages, ModelRequest(parts=cancellations)]
+
+
+@logfire.instrument("run_and_return_partial", extract_args=False)
+async def run_and_return_partial(
+    agent, *, user_prompt, deps, usage_limits=None, **kwargs
+):
+    """Run ``agent``, degrading to a partial answer if it exhausts its budget.
+
+    On ``UsageLimitExceeded`` the accumulated history is replayed once with no
+    toolsets and a prompt telling the model to finalise. The caller therefore
+    gets the agent's usual output type either way, and only sees the exception
+    if the fallback attempt also fails.
+    """
+    limits = usage_limits if usage_limits is not None else AGENT_USAGE_LIMITS
+
+    with capture_run_messages() as messages:
+        try:
+            return await agent.run(
+                user_prompt=user_prompt, deps=deps, usage_limits=limits, **kwargs
+            )
+        except UsageLimitExceeded as exc:
+            if not messages:
+                # Nothing was gathered, so there is no partial answer to give.
+                raise
+
+            logfire.warn(
+                "Agent hit its usage limit; falling back to a partial answer",
+                exc_info=exc,
+                messages=len(messages),
+            )
+
+            history = _close_dangling_tool_calls(list(messages))
+            history.append(
+                ModelRequest(parts=[UserPromptPart(content=FINALIZE_PROMPT)])
+            )
+
+            result = await agent.run(
+                message_history=history,
+                deps=deps,
+                usage_limits=FINALIZE_USAGE_LIMITS,
+                toolsets=[],
+                **kwargs,
+            )
+            logfire.info("Returned a partial answer after hitting the usage limit")
+            return result

--- a/tiger_agent/agent/limits_specs.py
+++ b/tiger_agent/agent/limits_specs.py
@@ -1,0 +1,115 @@
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+
+from tiger_agent.agent.limits import (
+    AGENT_USAGE_LIMITS,
+    _close_dangling_tool_calls,
+    make_limit_warner,
+)
+
+
+def _tool_call(tool_name: str, call_id: str) -> ModelResponse:
+    return ModelResponse(
+        parts=[ToolCallPart(tool_name=tool_name, args={}, tool_call_id=call_id)]
+    )
+
+
+def _tool_return(tool_name: str, call_id: str) -> ModelRequest:
+    return ModelRequest(
+        parts=[ToolReturnPart(tool_name=tool_name, content="ok", tool_call_id=call_id)]
+    )
+
+
+def _unanswered(messages) -> set[str]:
+    """Tool calls with no matching return -- what Anthropic rejects."""
+    calls = {
+        part.tool_call_id
+        for message in messages
+        if isinstance(message, ModelResponse)
+        for part in message.parts
+        if isinstance(part, ToolCallPart)
+    }
+    returns = {
+        part.tool_call_id
+        for message in messages
+        if isinstance(message, ModelRequest)
+        for part in message.parts
+        if isinstance(part, ToolReturnPart)
+    }
+    return calls - returns
+
+
+class TestCloseDanglingToolCalls:
+    def test_empty_history_is_left_alone(self):
+        assert _close_dangling_tool_calls([]) == []
+
+    def test_complete_history_is_unchanged(self):
+        messages = [
+            ModelRequest(parts=[UserPromptPart(content="summarize case 123")]),
+            _tool_call("search_docs", "c1"),
+            _tool_return("search_docs", "c1"),
+            ModelResponse(parts=[TextPart(content="done")]),
+        ]
+
+        assert _close_dangling_tool_calls(messages) == messages
+
+    def test_outstanding_calls_get_a_cancellation_result(self):
+        messages = [
+            ModelRequest(parts=[UserPromptPart(content="summarize case 123")]),
+            _tool_call("search_docs", "c1"),
+            _tool_return("search_docs", "c1"),
+            ModelResponse(
+                parts=[
+                    ToolCallPart(tool_name="search_docs", args={}, tool_call_id="c2"),
+                    ToolCallPart(tool_name="slack_search", args={}, tool_call_id="c3"),
+                ]
+            ),
+        ]
+
+        repaired = _close_dangling_tool_calls(messages)
+
+        # One appended request answering both orphaned calls, nothing dropped.
+        assert len(repaired) == len(messages) + 1
+        assert repaired[: len(messages)] == messages
+        assert {part.tool_call_id for part in repaired[-1].parts} == {"c2", "c3"}
+
+    def test_repaired_history_satisfies_the_tool_result_invariant(self):
+        messages = [
+            ModelRequest(parts=[UserPromptPart(content="summarize case 123")]),
+            _tool_call("search_docs", "c1"),
+        ]
+
+        assert _unanswered(messages) == {"c1"}
+        assert _unanswered(_close_dangling_tool_calls(messages)) == set()
+
+    def test_context_is_preserved_rather_than_truncated(self):
+        """The point of the fallback is the gathered context; it must survive."""
+        messages = [
+            ModelRequest(parts=[UserPromptPart(content="summarize case 123")]),
+            *[_tool_call("search_docs", f"c{i}") for i in range(5)],
+        ]
+
+        repaired = _close_dangling_tool_calls(messages)
+
+        assert all(original in repaired for original in messages)
+
+
+class TestLimits:
+    def test_backstop_matches_the_documented_budget(self):
+        assert AGENT_USAGE_LIMITS.request_limit == 150
+        assert AGENT_USAGE_LIMITS.output_tokens_limit == 40_000
+
+    def test_warner_fires_before_the_backstop(self):
+        warner = make_limit_warner()
+
+        assert warner.max_iterations == AGENT_USAGE_LIMITS.request_limit
+        assert 0 < warner.warning_threshold < 1
+        # Warnings must start strictly before the hard limit, with room to finish.
+        assert warner.max_iterations * warner.warning_threshold < warner.max_iterations
+        assert warner.critical_remaining_iterations > 0

--- a/tiger_agent/agent/utils.py
+++ b/tiger_agent/agent/utils.py
@@ -16,6 +16,7 @@ from tiger_agent.agent.constants import (
     SPAM_DETECTION_MODEL,
     SPAM_DETECTION_USAGE_LIMITS,
 )
+from tiger_agent.agent.limits import make_limit_warner
 from tiger_agent.agent.tiger_agent import (
     INVESTIGATOR_SYSTEM_PROMPT_REGEX,
     SPAM_DETECTION_PROMPT_REGEX,
@@ -200,6 +201,7 @@ async def create_agent_and_context(
                 max_tokens=800_000,
                 max_tool_output_tokens=50_000,
             ),
+            make_limit_warner(),
             SubAgents(
                 agents=[
                     SubAgent(
@@ -234,6 +236,7 @@ async def create_agent_and_context(
                                     max_tokens=800_000,
                                     max_tool_output_tokens=50_000,
                                 ),
+                                make_limit_warner(),
                             ],
                         )
                     )

--- a/tiger_agent/prompts/system_prompt.md
+++ b/tiger_agent/prompts/system_prompt.md
@@ -50,6 +50,21 @@ When a user asks to be notified, alerted, or wants a rule created, call the `cre
 
 {% endif %}
 
+## Handling tool failures
+
+When a tool fails, the shape of the failure tells you what to do next. Do NOT default to retrying the same tool with a mutated input — that pattern (edit-distance guessing on an ID, hunting for a "typo") burns tool-call budget without ever finding the answer.
+
+**When a tool returns "not found" or a validation error on an identifier:**
+
+- Read the error. If it names an expected format, prefix, or example, that is the ground truth — use it.
+- Do NOT retry the same tool with variants of the same ID (appending a character, changing the last character, permuting the middle). If the ID was well-formed and the tool said "not found", the ID either points at a different object type or doesn't exist. Either way, more variants won't help.
+- If a related tool applies to that ID (a different entity type, a different lookup path), switch tools.
+- If no other tool applies, surface the ID as an unresolvable finding and move on. An unresolved ID is a valid outcome; a 100-request retry loop is not.
+
+**When a tool errors on transient/upstream failure** (timeout, 5xx, connection): one retry is fine. A second retry is rarely worth it — treat persistent transient failure as a Gap.
+
+**Hard budget:** across a single investigation or response, never call the same tool with edit-distance variants of the same argument more than **twice**. If you find yourself about to make a third variant call, stop — the answer is a different tool or an "unresolved" finding, not another guess.
+
 ## Delegating Investigations
 
 **Prefer delegating via `delegate_task` when:**

--- a/tiger_agent/tasks/handlers/__init__.py
+++ b/tiger_agent/tasks/handlers/__init__.py
@@ -4,12 +4,12 @@ Re-exports the dispatch base classes and every concrete handler so callers can
 continue to write `from tiger_agent.tasks.handlers import ...`.
 """
 
+from tiger_agent.agent.limits import AGENT_USAGE_LIMITS
 from tiger_agent.tasks.handlers.agent_feedback_rating import AgentFeedbackRatingHandler
 from tiger_agent.tasks.handlers.agent_feedback_request_reminder import (
     AgentFeedbackRequestReminderHandler,
 )
 from tiger_agent.tasks.handlers.base import (
-    AGENT_USAGE_LIMITS,
     TaskHandler,
     TaskProcessor,
 )

--- a/tiger_agent/tasks/handlers/base.py
+++ b/tiger_agent/tasks/handlers/base.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from typing import ClassVar
 
 import logfire
-from pydantic_ai import UsageLimitExceeded, UsageLimits
+from pydantic_ai import UsageLimitExceeded
 
 from tiger_agent.agent.constants import USER_DEFINED_EVENTS_ENABLED
 from tiger_agent.agent.tiger_agent import TigerAgent
@@ -24,8 +24,6 @@ from tiger_agent.tasks.user_defined_rules import evaluate_user_defined_rules
 from tiger_agent.types import HarnessContext
 
 logger = logging.getLogger(__name__)
-
-AGENT_USAGE_LIMITS = UsageLimits(output_tokens_limit=40_000, request_limit=150)
 
 
 class TaskHandler(ABC):

--- a/tiger_agent/tasks/handlers/salesforce_assignment_changed.py
+++ b/tiger_agent/tasks/handlers/salesforce_assignment_changed.py
@@ -2,6 +2,7 @@ from typing import cast
 
 import logfire
 
+from tiger_agent.agent.limits import AGENT_USAGE_LIMITS, run_and_return_partial
 from tiger_agent.agent.types import AgentSalesforceResponse
 from tiger_agent.agent.utils import create_agent_and_context
 from tiger_agent.db.utils import upsert_feedback_request_reminder
@@ -18,7 +19,7 @@ from tiger_agent.slack.utils import (
     post_response,
     request_feedback,
 )
-from tiger_agent.tasks.handlers.base import AGENT_USAGE_LIMITS, TaskHandler
+from tiger_agent.tasks.handlers.base import TaskHandler
 from tiger_agent.tasks.types import Task
 
 
@@ -42,7 +43,10 @@ class SalesforceAssignmentChangedHandler(TaskHandler):
             channel_to_respond=SALESFORCE_CASE_CHANNEL,
         )
 
-        response = await agent_and_ctx.agent.run(
+        # A case summary built from partial research still helps the assignee;
+        # dying on the budget leaves the case with no Slack thread at all.
+        response = await run_and_return_partial(
+            agent_and_ctx.agent,
             user_prompt=agent_and_ctx.user_prompt,
             deps=agent_and_ctx.ctx,
             usage_limits=AGENT_USAGE_LIMITS,

--- a/tiger_agent/tasks/handlers/slack.py
+++ b/tiger_agent/tasks/handlers/slack.py
@@ -1,6 +1,7 @@
 import logfire
 from pydantic_ai.messages import PartDeltaEvent, PartStartEvent, TextPart, TextPartDelta
 
+from tiger_agent.agent.limits import AGENT_USAGE_LIMITS
 from tiger_agent.agent.utils import create_agent_and_context
 from tiger_agent.db.utils import usage_limit_reached, user_ignored
 from tiger_agent.slack.types import SlackAppMentionEvent, SlackMessageEvent
@@ -10,7 +11,7 @@ from tiger_agent.slack.utils import (
     set_status,
     stream_response_to_mention,
 )
-from tiger_agent.tasks.handlers.base import AGENT_USAGE_LIMITS, TaskHandler
+from tiger_agent.tasks.handlers.base import TaskHandler
 from tiger_agent.tasks.types import Task
 
 

--- a/tiger_agent/tasks/handlers/user_defined_rule_match.py
+++ b/tiger_agent/tasks/handlers/user_defined_rule_match.py
@@ -3,10 +3,11 @@ import json
 import logfire
 from pydantic_ai import Agent, Tool
 
+from tiger_agent.agent.limits import AGENT_USAGE_LIMITS
 from tiger_agent.salesforce.types import UserDefinedRuleMatch
 from tiger_agent.salesforce.utils import create_case_url
 from tiger_agent.slack.utils import post_response
-from tiger_agent.tasks.handlers.base import AGENT_USAGE_LIMITS, TaskHandler
+from tiger_agent.tasks.handlers.base import TaskHandler
 from tiger_agent.tasks.types import Task
 
 


### PR DESCRIPTION
## Problem

When a run exhausts `AGENT_USAGE_LIMITS`, pydantic-ai raises `UsageLimitExceeded`. For Salesforce events `TaskProcessor` logs it and returns, so the case gets no summary, no Slack thread, and nobody is told.

Over a recent 5-day window that happened to **22 traces**, which had spent **679M input tokens** between them — averaging 30.9M per trace against 1.4M for a normal run. The cap stopped the spend but discarded all the research that paid for it.

All 22 were Salesforce-triggered. Not one human Slack conversation hit the cap.

## Approach

Three layers now sit between a long run and that outcome. The hard cap becomes a backstop that should rarely fire, rather than the primary control.

### 1. Warn the model before it runs out

`LimitWarnerCapability` was already in the dependency tree via `pydantic_ai_summarization` and **had never been wired up** — only `ContextManagerCapability` was imported from it.

It injects an escalating warning as a *trailing user message* (the library does this deliberately; models deprioritize appended system text). Warnings start at 70% of a limit and turn critical with three requests to spare, giving the agent room to stop searching and write its answer before anything is enforced. Added to both the main agent and the investigator subagent.

### 2. Tell the model how to handle a failing tool

`system_prompt.md` gains a "Handling tool failures" section. The load-bearing rule:

> never call the same tool with edit-distance variants of the same argument more than **twice**

This targets loops visible in the telemetry: 61 `No user found with ID: 00G…` retries where group/queue IDs were passed to `get_user_details`, and one trace that made **100 near-identical `pg-aiguide::search_docs` calls**, rephrasing the same query until the cap killed it. Enforcement without instruction just means the agent burns budget right up to the limit.

### 3. Return a partial answer instead of nothing

`run_and_return_partial()` wraps `agent.run` in `capture_run_messages()` — needed because when the run raises there is no result object to read the history from. On `UsageLimitExceeded` it replays the accumulated history once with `toolsets=[]` and a prompt to finalise with what it has, stating plainly what it could not determine.

Removing the toolsets is what makes it terminate: the model physically cannot resume the loop it was just stopped for. The caller gets the agent's usual output type either way and only sees the exception if the fallback also fails.

**The subtle part:** a run cut short by a *token* limit stops **after** a model response, so the history can end with `tool_use` blocks that never received results — and Anthropic rejects any history containing a `tool_use` without a matching `tool_result`. Truncating back to the last clean exchange would throw away the very context worth keeping, so `_close_dangling_tool_calls` synthesises a cancellation result for each orphan instead. Nothing is dropped and the API invariant holds.

Applied to `SalesforceAssignmentChangedHandler` — the handler whose output humans actually read. Deliberately **not** applied to `detect_spam_case`: today a budget abort means the case is *not* filtered, and forcing a rushed spam verdict risks burying a real customer case. Failing closed is safer there.

## Also in this PR

`AGENT_USAGE_LIMITS` moves into the new `agent/limits.py`, next to the warner it is sized against. Its three consumers now import it from there rather than through `tasks.handlers.base`, which imported it without ever using it.

**Limits themselves are unchanged** at 150 requests / 40K output tokens. With the warner in front the exact numbers matter much less, and changing them is a separate decision.

## Testing

- New `limits_specs.py`: 7 specs covering the history repair — empty history, already-complete history, orphaned calls getting cancellations, the `tool_use`↔`tool_result` invariant holding after repair, and that no original message is dropped.
- Full suite: **110 passing** (103 before).
- Ruff clean on all touched files; repo-wide count unchanged from baseline.

## Follow-ups, deliberately not here

- `openrouter_cache_messages` / `anthropic_cache` — modelled at ~84% further input reduction, but it is a caching change and wants its own before/after measurement.
- In-band per-tool budgets and duplicate-query suppression via `create_wrapped_process_tool_call`.
- Trimming `eon-skills`, where `salesforce-case-information-gathering` implies 30-50 tool calls with no budget — roughly 90-150 model turns through the tigerlabs proxy, meaning the Salesforce handlers approach the cap by design.

## What to watch after deploy

The logfire span `run_and_return_partial` and the log line `Agent hit its usage limit; falling back to a partial answer` show how often the backstop fires. If the warner is working, that count should be low and falling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)