### PR TITLE
Cache the conversation, not just instructions and tool definitions

### DIFF
--- a/tiger_agent/agent/utils.py
+++ b/tiger_agent/agent/utils.py
@@ -49,11 +49,25 @@ from tiger_agent.utils import (
 # Only the settings matching the active model's provider prefix are read; the rest are
 # ignored, so it's safe to set both Anthropic's and OpenRouter's cache keys regardless of
 # whether `model` is an `anthropic:` or `openrouter:` model string.
+#
+# Caching instructions and tool definitions only ever covers a fixed-size prefix, so its
+# value decays as an agent loop grows -- on SalesforceAssignmentChanged that was a ~21.5K
+# cached block against requests averaging 137K. Also caching the conversation makes the
+# cached prefix grow with the run, so each turn pays full price for the new tool result
+# rather than for the whole history again.
+#
+# Anthropic gets `anthropic_cache` rather than `anthropic_cache_messages`: it is the
+# native form, where the server moves the breakpoint forward on its own. The `_messages`
+# variant is the fallback for gateways that cannot pass the top-level parameter, and the
+# two are mutually exclusive. OpenRouter has no automatic equivalent, so it takes the
+# explicit per-message breakpoint.
 PROMPT_CACHE_MODEL_SETTINGS: dict[str, Any] = {
     "anthropic_cache_instructions": True,
     "anthropic_cache_tool_definitions": True,
+    "anthropic_cache": True,
     "openrouter_cache_instructions": True,
     "openrouter_cache_tool_definitions": True,
+    "openrouter_cache_messages": True,
 }
 
 


### PR DESCRIPTION
## Problem

#270 enabled prompt caching for system instructions and tool definitions. It works — cache reads started flowing the hour it deployed — but it only ever covers a **fixed-size prefix**, so its value decays as an agent loop grows.

Measured over the 5 days since, by handler:

| Handler | Calls | Input tokens | Cache read | Hit rate |
|---|---|---|---|---|
| `SlackTaskHandler` | 356 | 31.4M | 9.06M | 28.8% |
| `SalesforceCaseCreated` | 36 | 3.43M | 0.98M | 28.7% |
| **`SalesforceAssignmentChanged`** | 83 | 11.3M | 1.78M | **15.7%** |

The most expensive handler gets the least benefit, and that's arithmetic rather than misconfiguration: the cached block averages ~21.5K tokens against requests averaging 137K. As a run grows past 400K, a constant numerator over a growing denominator can only shrink.

## Change

Two keys in `PROMPT_CACHE_MODEL_SETTINGS`:

```python
"anthropic_cache": True,           # native automatic breakpoint
"openrouter_cache_messages": True, # explicit rolling breakpoint
```

This moves the cache breakpoint to the end of the request, so the cached prefix grows with the conversation. Each turn then pays full price only for the new tool result rather than for the whole history again.

Anthropic gets `anthropic_cache` rather than `anthropic_cache_messages`. The former passes the top-level parameter and lets the server move the breakpoint forward itself; the latter is documented as the fallback *"for Anthropic-compatible gateways and proxies that don't support the top-level automatic caching parameter."* They are mutually exclusive — pydantic-ai raises `UserError` if both are set. OpenRouter has no automatic equivalent, so it takes the explicit per-message breakpoint, and that's the path production actually uses today (`gen_ai.system` is `openrouter`).

## Expected impact

Modelled against 8 real `SalesforceAssignmentChanged` traces using their actual per-turn token sequences. For an append-only loop a rolling breakpoint means turn *N* reads turn *N−1*'s request from cache and writes only the delta, so per turn: `0.1 × prev + 1.25 × (current − prev)`. Prefix breaks (where token count *dropped*, indicating compaction or a subagent boundary) were charged full write price.

| Turns | Input tokens | Prefix breaks | Cost now | Modelled | Saved |
|---|---|---|---|---|---|
| 116 | 59.5M | 0 | 59.5M | 7.10M | **88.1%** |
| 89 | 22.3M | 0 | 22.3M | 3.00M | **86.5%** |
| 43 | 4.56M | 2 | 4.56M | 0.98M | 78.6% |
| 32 | 3.92M | 7 | 3.92M | 1.99M | 49.2% |

**Weighted across all eight: 100.7M → 16.1M, an ~84% reduction.** Savings track prefix breaks almost perfectly, and the two most expensive traces had zero — long monotonic loops are exactly the shape prefix caching is built for. This inverts the current picture, where long runs benefit least.

## Why the write premium isn't a risk

Cache writes cost 1.25x and reads save 0.9x, so the break-even read:write ratio is **0.28:1**. Current production is running **13:1** (9.06M read against 688K write on the Slack handler). Even a run averaging ~1.3 turns comes out ahead, and the median turn counts are 5 / 10 / 25.

## TTL verified

The 5m default only helps if turns are close together. Checked all **361 inter-turn gaps** across those traces: **zero exceeded 300s**, most under a second, the 116-turn trace averaging 0.2s. One gap hit exactly 300.0s — likely a 5-minute MCP tool timeout, which would drop the cache. That's 1 in 361, not worth paying 2x writes for a `'1h'` TTL.

## Caveats

- Two traces show *negative* average inter-turn gaps, meaning concurrent investigator subagent calls with their own histories. The linear model conflates those streams, so their numbers are approximate — though they're also the low-saving rows, so the estimate is likely conservative.
- Break detection only catches breaks visible as a token *decrease*; a same-size history rewrite would be missed.
- Compaction invalidates the prefix by design. Today that's ~0.3% of requests (41 of ~13,900 exceeded 700K), so it's not a material drag.

## Testing

- All 6 keys validated against `AnthropicModelSettings` / `OpenRouterModelSettings` annotations. This matters: these are `total=False` TypedDicts, so a typo'd key is **silently ignored** with no error and no caching.
- Asserted `anthropic_cache` and `anthropic_cache_messages` are not both set.
- Breakpoint budget: 3 of Anthropic's 4 slots (tools, system, messages). `openrouter_max_cache_points` is 4 for Anthropic models, and pydantic-ai trims message breakpoints if a provider limit is exceeded.
- 103 tests passing, ruff clean.

## What to watch

Re-run the per-handler hit rate after deploy. `SalesforceAssignmentChanged` at **15.7%** is the signal — it should rise sharply. Also confirm read:write stays well above 1:1. Give it a full weekday: weekend volume was ~70 calls/day against ~4,000 on weekdays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)