### PR TITLE
Stop replaying Salesforce feed items

### DIFF
--- a/tiger_agent/db/utils.py
+++ b/tiger_agent/db/utils.py
@@ -434,21 +434,22 @@ async def filter_new_feed_items(
     if not feed_items:
         return []
 
-    if not feed_items:
-        return []
+    items_json = Jsonb([{"id": item.Id} for item in feed_items])
 
-    items_json = Jsonb(
-        [{"id": item.Id, "created_date": item.CreatedDate} for item in feed_items]
-    )
-
+    # Match on the feed-item Id alone. The Id is already unique, so adding
+    # event_ts can only produce false negatives -- and for EmailMessage it
+    # reliably does: that event_ts derives from MessageDate, which Salesforce
+    # backdates and later revises. A revised date both re-enters the poll
+    # window and no longer equals the stored one, so the item is treated as
+    # new. One message was observed with 79 distinct dates, re-posted to the
+    # customer's Slack thread each time.
     def get_already_handled_query(table_name: str) -> str:
         return f"""
             SELECT elem->>'id' AS id
             FROM jsonb_array_elements(%s::jsonb) AS elem
             WHERE EXISTS (
                 SELECT 1 FROM agent.{table_name}
-                WHERE event_ts = (elem->>'created_date')::timestamptz
-                  AND event->>'type' = 'salesforce_event'
+                WHERE event->>'type' = 'salesforce_event'
                   AND event->>'subtype' = 'new_feed_item'
                   AND event->'feed_item'->>'Id' = elem->>'id'
             )

--- a/tiger_agent/salesforce/case_feed_item_poller.py
+++ b/tiger_agent/salesforce/case_feed_item_poller.py
@@ -45,6 +45,7 @@ class SalesforceCaseFeedItemPoller:
         self._poll_interval_seconds = poll_interval_seconds
         self._last_poll: datetime | None = None
         self._bot_sf_user_id: str | None = None
+        self._poll_task: asyncio.Task[None] | None = None
 
     def _get_bot_sf_user_id(self) -> str | None:
         """Fetch and cache the Salesforce user ID of the integration user."""
@@ -65,7 +66,7 @@ class SalesforceCaseFeedItemPoller:
             if self._last_poll
             else (datetime.now(UTC) - timedelta(hours=INITIAL_LOOKBACK_IN_HOURS))
         )
-        self._last_poll = datetime.now(UTC)
+        poll_started_at = datetime.now(UTC)
         since_str = since.strftime("%Y-%m-%dT%H:%M:%SZ")
 
         case_feed_items = sorted(
@@ -91,6 +92,7 @@ class SalesforceCaseFeedItemPoller:
         )
 
         if not filtered_new_feed_items:
+            self._last_poll = poll_started_at
             return
 
         logfire.info("New case feed items found", count=len(filtered_new_feed_items))
@@ -102,9 +104,27 @@ class SalesforceCaseFeedItemPoller:
                     "Error handling new feed item", feed_item_id=feed_item.Id
                 )
 
+        # Only advance once the poll has run to completion. Setting this up
+        # front meant a mid-poll exception still moved the cursor past a window
+        # that was never processed.
+        self._last_poll = poll_started_at
+
+    async def _poll_if_idle(self) -> None:
+        """Skip this tick when the previous poll is still running.
+
+        ``schedule`` fires every ``poll_interval_seconds`` regardless of whether
+        the last poll finished. Without this guard two polls overlap, and since
+        each computes its own window from ``_last_poll`` they can enqueue the
+        same feed items twice.
+        """
+        if self._poll_task is not None and not self._poll_task.done():
+            logfire.info("Skipping case feed poll; previous poll still running")
+            return
+        self._poll_task = asyncio.create_task(self._poll())
+
     def start(self, run_immediate: bool = False) -> None:
         def job():
-            asyncio.create_task(self._poll())
+            asyncio.create_task(self._poll_if_idle())
 
         schedule.every(self._poll_interval_seconds).seconds.do(job)
         logger.info(

--- a/tiger_agent/salesforce/case_feed_item_poller_specs.py
+++ b/tiger_agent/salesforce/case_feed_item_poller_specs.py
@@ -1,0 +1,109 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tiger_agent.salesforce.case_feed_item_poller import SalesforceCaseFeedItemPoller
+
+MODULE = "tiger_agent.salesforce.case_feed_item_poller"
+
+
+@pytest.fixture
+def poller(make_pool_mock):
+    return SalesforceCaseFeedItemPoller(
+        pool=make_pool_mock(),
+        salesforce_client=MagicMock(),
+        handler=AsyncMock(),
+        poll_interval_seconds=20,
+    )
+
+
+@pytest.fixture
+def stub_salesforce():
+    """Stub the two Salesforce fetches and the dedupe so _poll is pure."""
+    with (
+        patch(f"{MODULE}.get_case_feed_items", return_value=[]) as feed,
+        patch(f"{MODULE}.get_case_email_messages", return_value=[]) as email,
+        patch(f"{MODULE}.filter_new_feed_items", new=AsyncMock(return_value=[])) as flt,
+    ):
+        yield {"feed": feed, "email": email, "filter": flt}
+
+
+class TestPollCursor:
+    async def test_advances_after_a_successful_poll(self, poller, stub_salesforce):
+        assert poller._last_poll is None
+
+        await poller._poll()
+
+        assert poller._last_poll is not None
+
+    async def test_does_not_advance_when_the_poll_raises(self, poller, stub_salesforce):
+        """A mid-poll failure must not skip the window it never processed."""
+        stub_salesforce["filter"].side_effect = RuntimeError("salesforce is down")
+
+        with pytest.raises(RuntimeError):
+            await poller._poll()
+
+        assert poller._last_poll is None
+
+    async def test_a_failed_poll_leaves_the_window_start_unchanged(
+        self, poller, stub_salesforce
+    ):
+        await poller._poll()
+        first_cursor = poller._last_poll
+
+        stub_salesforce["filter"].side_effect = RuntimeError("transient")
+        with pytest.raises(RuntimeError):
+            await poller._poll()
+
+        assert poller._last_poll == first_cursor
+
+
+class TestPollReentrancy:
+    async def test_skips_the_tick_while_a_poll_is_in_flight(self, poller):
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_poll():
+            started.set()
+            await release.wait()
+
+        with patch.object(poller, "_poll", side_effect=slow_poll):
+            await poller._poll_if_idle()
+            await started.wait()
+            first_task = poller._poll_task
+
+            # second tick arrives while the first is still running
+            await poller._poll_if_idle()
+            assert poller._poll_task is first_task
+
+            release.set()
+            await first_task
+
+    async def test_starts_a_new_poll_once_the_previous_finished(self, poller):
+        with patch.object(poller, "_poll", new=AsyncMock()):
+            await poller._poll_if_idle()
+            first_task = poller._poll_task
+            await first_task
+
+            await poller._poll_if_idle()
+            assert poller._poll_task is not first_task
+            await poller._poll_task
+
+
+class TestDedupePredicate:
+    def test_dedupe_does_not_key_on_the_mutable_timestamp(self):
+        """EmailMessage event_ts derives from MessageDate, which Salesforce revises."""
+        import inspect
+
+        from tiger_agent.db.utils import filter_new_feed_items
+
+        # Comments in this function legitimately discuss event_ts, so assert
+        # against the code only.
+        code = "\n".join(
+            line
+            for line in inspect.getsource(filter_new_feed_items).splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        assert "feed_item'->>'Id' = elem->>'id'" in code
+        assert "event_ts" not in code


### PR DESCRIPTION
## Problem

One EmailMessage was observed re-posting into a customer's Slack thread **79 times**. Over a single day, **315 distinct feed items became 973 enqueued tasks**.

This is the one item on the cost-investigation list that is a *correctness* defect rather than a cost one — the tokens are trivial (~1.6% of a day), but customers saw duplicate messages.

Two independent bugs combined.

## 1. Dedupe keyed on a mutable field

`db/utils.py` matched on feed-item Id **AND** an exact `event_ts` equality:

```sql
WHERE event_ts = (elem->>'created_date')::timestamptz
  AND ...
  AND event->'feed_item'->>'Id' = elem->>'id'
```

For EmailMessage, that timestamp comes from `MessageDate` (`salesforce/utils.py:465` maps `CreatedDate=r.get("MessageDate")`), which Salesforce backdates to the send time and later revises. When it moves, the record both re-enters the SOQL poll window (`:443` filters `MessageDate > since`) *and* stops matching the stored row — so it reads as new. One item was seen with **79 distinct `MessageDate` values**.

The Id is already unique, so the timestamp term could only ever produce false negatives. Removed.

## 2. Overlapping polls

`schedule` fires every 20s whether or not the previous poll finished, and the tick was a bare fire-and-forget `asyncio.create_task(self._poll())`. Each poll computes its window from `_last_poll`, so two in flight derive different windows over the same data and both enqueue — a duplicate path independent of bug 1.

Ticks now skip while a poll is in flight, logging when they do.

## 3. Cursor advanced before the work

`_last_poll` was set at the top of `_poll`, before any Salesforce query. A mid-poll exception still moved it, so the unprocessed window was skipped and never retried. It now advances only on completion.

## Testing

New `case_feed_item_poller_specs.py`, 6 specs:
- cursor advances after a successful poll
- cursor does **not** advance when the poll raises, and a failed poll leaves the previous cursor untouched
- a tick is skipped while a poll is in flight; a new poll starts once the previous finished
- the dedupe SQL no longer references `event_ts` (comment lines stripped, so prose about the bug doesn't satisfy the assertion)

Full suite **116 passing** (110 + 6). Ruff clean on changed files — the one remaining `W291` at `db/utils.py:352` is pre-existing on main, verified by stashing.

## Notes for review

- **Not** changing `MessageDate` at source. Fix 1 makes the replay non-fatal; switching the SOQL filter and the `CreatedDate` mapping to the real creation timestamp is a separate, riskier change that alters which records the poll sees at all.
- A unique index on the feed-item Id was in the plan for this PR and is **not** included — `agent.event` rows are deleted on success and moved to `agent.event_hist`, so a naive unique constraint would need to span both tables and would interact with the retry path. Worth doing, but it deserves its own PR with a migration rather than riding along here.
- The 12-hour `INITIAL_LOOKBACK_IN_HOURS` replay on every process start is untouched; with the dedupe fixed it is no longer harmful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)