### PR TITLE
Stop a run before its context reaches the model ceiling

### DIFF
--- a/tiger_agent/agent/constants.py
+++ b/tiger_agent/agent/constants.py
@@ -44,11 +44,35 @@ SPAM_DETECTION_MODEL = os.environ.get(
 #
 #   0.7 x CONTEXT       warner starts telling the model to converge
 #   0.9 x CONTEXT       ContextManagerCapability attempts compaction
-#   AGENT_MAX_REQUESTS  hard stop on turn count
+#   REQUEST_INPUT       run stops with UsageLimitExceeded -> partial answer
+#   model window        provider would reject -- never reached
 # --------------------------------------------------------------------------
 
 AGENT_MAX_REQUESTS: int = int(os.getenv("AGENT_MAX_REQUESTS", "150"))
 AGENT_MAX_OUTPUT_TOKENS: int = int(os.getenv("AGENT_MAX_OUTPUT_TOKENS", "40000"))
+
+# Stop a run before its context reaches the model's ceiling.
+#
+# A run was observed dying on "prompt is too long: 1002326 tokens > 1000000
+# maximum". That surfaces as a provider 400, which is the worst shape available:
+# the oversized request is billed, nothing is salvaged, and because the prompt
+# is a deterministic function of the event, every requeue rebuilds it and fails
+# identically.
+#
+# pydantic-ai checks this against each response's input tokens as it arrives.
+# Context grows monotonically, so catching "this turn was 850K" ends the run
+# before the next turn would breach 1M -- and it raises UsageLimitExceeded, so
+# the warner already counts down toward it and run_and_return_partial still
+# turns it into a partial answer.
+#
+# Sized to sit above the compaction trigger (0.9 x 800K = 720K) so context
+# management gets first attempt, and far enough below a 1M window that one more
+# turn cannot clear it: a single tool result is capped at 50K tokens by
+# ContextManagerCapability and ~50K by MAX_TOOL_RESULT_CHARS. Only 39 of 20,652
+# calls in a six-day sample exceeded 720K at all, so routine work never sees it.
+AGENT_MAX_REQUEST_INPUT_TOKENS: int = int(
+    os.getenv("AGENT_MAX_REQUEST_INPUT_TOKENS", "850000")
+)
 
 # The budget ContextManagerCapability manages against; compaction fires at
 # 0.9x this.

--- a/tiger_agent/agent/limits.py
+++ b/tiger_agent/agent/limits.py
@@ -30,34 +30,12 @@ from pydantic_ai_summarization import LimitWarnerCapability
 
 from tiger_agent.agent.constants import (
     AGENT_CRITICAL_REMAINING_REQUESTS,
-    AGENT_MAX_CONTEXT_TOKENS,
     AGENT_MAX_OUTPUT_TOKENS,
+    AGENT_MAX_REQUEST_INPUT_TOKENS,
     AGENT_MAX_REQUESTS,
-    AGENT_SOFT_TOTAL_TOKENS,
     AGENT_WARNING_THRESHOLD,
     FINALIZE_MAX_REQUESTS,
 )
-
-# Stop a run before its context reaches the model's ceiling.
-#
-# A run was observed dying on "prompt is too long: 1002326 tokens > 1000000
-# maximum". That surfaces as a provider 400, which is the worst shape available:
-# the oversized request is billed, nothing is salvaged, and because the prompt
-# is a deterministic function of the event, every requeue rebuilds it and fails
-# identically.
-#
-# pydantic-ai checks this against each response's input tokens as it arrives.
-# Context grows monotonically, so catching "this turn was 850K" ends the run
-# before the next turn would breach 1M -- and it raises UsageLimitExceeded, so
-# the warner already counts down toward it and run_and_return_partial still
-# turns it into a partial answer.
-#
-# Sized to sit above the compaction trigger (0.9 x 800K = 720K) so context
-# management gets first attempt, and far enough below a 1M window that one more
-# turn cannot clear it: a single tool result is capped at 50K tokens by
-# ContextManagerCapability and ~50K by MAX_TOOL_RESULT_CHARS. Only 39 of 20,652
-# calls in a six-day sample exceeded 720K at all, so routine work never sees it.
-AGENT_MAX_REQUEST_INPUT_TOKENS = 850_000
 
 AGENT_USAGE_LIMITS = UsageLimits(
     output_tokens_limit=AGENT_MAX_OUTPUT_TOKENS,
@@ -91,10 +69,16 @@ def make_limit_warner() -> LimitWarnerCapability:
     and become critical with three requests to spare, which gives the agent
     room to stop searching and write its answer before anything is enforced.
     """
+    # Every number here is interpolated verbatim into the message the model
+    # reads ("Context window: 812345/850000 tokens used"), so each one must be a
+    # limit that is actually enforced. A countdown to a ceiling that never
+    # arrives teaches the model to discount the warnings that do matter.
     return LimitWarnerCapability(
         max_iterations=AGENT_MAX_REQUESTS,
-        max_context_tokens=AGENT_MAX_CONTEXT_TOKENS,
-        max_total_tokens=AGENT_SOFT_TOTAL_TOKENS,
+        max_context_tokens=AGENT_MAX_REQUEST_INPUT_TOKENS,
+        # No cumulative token limit is enforced yet, so there is nothing
+        # truthful to count down against. Set this the moment one exists.
+        max_total_tokens=None,
         warning_threshold=AGENT_WARNING_THRESHOLD,
         critical_remaining_iterations=AGENT_CRITICAL_REMAINING_REQUESTS,
     )

--- a/tiger_agent/agent/limits.py
+++ b/tiger_agent/agent/limits.py
@@ -38,9 +38,31 @@ from tiger_agent.agent.constants import (
     FINALIZE_MAX_REQUESTS,
 )
 
+# Stop a run before its context reaches the model's ceiling.
+#
+# A run was observed dying on "prompt is too long: 1002326 tokens > 1000000
+# maximum". That surfaces as a provider 400, which is the worst shape available:
+# the oversized request is billed, nothing is salvaged, and because the prompt
+# is a deterministic function of the event, every requeue rebuilds it and fails
+# identically.
+#
+# pydantic-ai checks this against each response's input tokens as it arrives.
+# Context grows monotonically, so catching "this turn was 850K" ends the run
+# before the next turn would breach 1M -- and it raises UsageLimitExceeded, so
+# the warner already counts down toward it and run_and_return_partial still
+# turns it into a partial answer.
+#
+# Sized to sit above the compaction trigger (0.9 x 800K = 720K) so context
+# management gets first attempt, and far enough below a 1M window that one more
+# turn cannot clear it: a single tool result is capped at 50K tokens by
+# ContextManagerCapability and ~50K by MAX_TOOL_RESULT_CHARS. Only 39 of 20,652
+# calls in a six-day sample exceeded 720K at all, so routine work never sees it.
+AGENT_MAX_REQUEST_INPUT_TOKENS = 850_000
+
 AGENT_USAGE_LIMITS = UsageLimits(
     output_tokens_limit=AGENT_MAX_OUTPUT_TOKENS,
     request_limit=AGENT_MAX_REQUESTS,
+    per_request_input_tokens_limit=AGENT_MAX_REQUEST_INPUT_TOKENS,
 )
 
 # The fallback call makes exactly one tool-free request, so it needs a budget of

--- a/tiger_agent/agent/limits_specs.py
+++ b/tiger_agent/agent/limits_specs.py
@@ -8,9 +8,11 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 
-from tiger_agent.agent.limits import (
+from tiger_agent.agent.constants import (
     AGENT_MAX_CONTEXT_TOKENS,
     AGENT_MAX_REQUEST_INPUT_TOKENS,
+)
+from tiger_agent.agent.limits import (
     AGENT_USAGE_LIMITS,
     FINALIZE_USAGE_LIMITS,
     _close_dangling_tool_calls,
@@ -166,3 +168,49 @@ class TestPerRequestContextCeiling:
     def test_the_finalize_pass_is_not_subject_to_it(self):
         """The salvage call must not be blocked by the budget that just tripped."""
         assert FINALIZE_USAGE_LIMITS.per_request_input_tokens_limit is None
+
+
+class TestWarnerMatchesEnforcedLimits:
+    """The warner interpolates its numbers straight into the model's context.
+
+    "Context window: 812345/850000 tokens used" is read as fact. If the figure
+    is not the one that actually stops the run, the model is either warned
+    about a ceiling that never arrives or blindsided by one it was never told
+    about -- and warnings that prove empty devalue the ones that do not.
+    """
+
+    def test_iteration_warning_matches_the_enforced_request_limit(self):
+        warner = make_limit_warner()
+
+        assert warner.max_iterations == AGENT_USAGE_LIMITS.request_limit
+
+    def test_context_warning_matches_the_enforced_per_request_ceiling(self):
+        warner = make_limit_warner()
+
+        assert warner.max_context_tokens == (
+            AGENT_USAGE_LIMITS.per_request_input_tokens_limit
+        )
+
+    def test_no_countdown_against_an_unenforced_total(self):
+        """AGENT_SOFT_TOTAL_TOKENS is a proposal, not a limit."""
+        warner = make_limit_warner()
+
+        assert AGENT_USAGE_LIMITS.total_tokens_limit is None
+        assert AGENT_USAGE_LIMITS.input_tokens_limit is None
+        assert warner.max_total_tokens is None
+
+    def test_every_warned_dimension_is_actually_enforced(self):
+        """Guards against drift as limits are tuned."""
+        warner = make_limit_warner()
+        enforced = {
+            "max_iterations": AGENT_USAGE_LIMITS.request_limit,
+            "max_context_tokens": AGENT_USAGE_LIMITS.per_request_input_tokens_limit,
+            "max_total_tokens": AGENT_USAGE_LIMITS.total_tokens_limit,
+        }
+
+        for field, enforced_value in enforced.items():
+            warned_value = getattr(warner, field)
+            if warned_value is not None:
+                assert warned_value == enforced_value, (
+                    f"warner {field}={warned_value} but nothing enforces that value"
+                )

--- a/tiger_agent/agent/limits_specs.py
+++ b/tiger_agent/agent/limits_specs.py
@@ -1,3 +1,4 @@
+import pytest
 from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
@@ -8,7 +9,10 @@ from pydantic_ai.messages import (
 )
 
 from tiger_agent.agent.limits import (
+    AGENT_MAX_CONTEXT_TOKENS,
+    AGENT_MAX_REQUEST_INPUT_TOKENS,
     AGENT_USAGE_LIMITS,
+    FINALIZE_USAGE_LIMITS,
     _close_dangling_tool_calls,
     make_limit_warner,
 )
@@ -113,3 +117,52 @@ class TestLimits:
         # Warnings must start strictly before the hard limit, with room to finish.
         assert warner.max_iterations * warner.warning_threshold < warner.max_iterations
         assert warner.critical_remaining_iterations > 0
+
+
+class TestPerRequestContextCeiling:
+    """The proactive half: stop before the provider rejects the prompt.
+
+    A provider 400 is the worst available shape -- the oversized request is
+    billed, nothing is salvaged, and the retry rebuilds it. Tripping
+    UsageLimitExceeded one turn earlier routes the same situation into the
+    warner / partial-answer / ack path that already exists.
+    """
+
+    def test_a_per_request_ceiling_is_set(self):
+        assert AGENT_USAGE_LIMITS.per_request_input_tokens_limit == (
+            AGENT_MAX_REQUEST_INPUT_TOKENS
+        )
+
+    def test_it_leaves_room_for_one_more_turn_under_a_1m_window(self):
+        """A single tool result is capped near 50K, so one turn cannot clear it."""
+        headroom = 1_000_000 - AGENT_MAX_REQUEST_INPUT_TOKENS
+
+        assert headroom >= 100_000
+
+    def test_it_sits_above_the_compaction_trigger(self):
+        """Context management gets first attempt; this is the wall behind it."""
+        compaction_trigger = AGENT_MAX_CONTEXT_TOKENS * 0.9
+
+        assert compaction_trigger < AGENT_MAX_REQUEST_INPUT_TOKENS
+
+    def test_the_warner_still_warns_before_the_ceiling(self):
+        warner = make_limit_warner()
+
+        first_warning_at = warner.max_context_tokens * warner.warning_threshold
+        assert first_warning_at < AGENT_MAX_REQUEST_INPUT_TOKENS
+
+    def test_it_raises_the_exception_the_fallback_already_handles(self):
+        """The whole point: overflow becomes UsageLimitExceeded, not a 400."""
+        from pydantic_ai import UsageLimitExceeded
+
+        with pytest.raises(UsageLimitExceeded):
+            AGENT_USAGE_LIMITS.check_per_request_input_tokens(
+                AGENT_MAX_REQUEST_INPUT_TOKENS + 1
+            )
+
+    def test_a_normal_request_passes(self):
+        AGENT_USAGE_LIMITS.check_per_request_input_tokens(324_132)  # observed p95
+
+    def test_the_finalize_pass_is_not_subject_to_it(self):
+        """The salvage call must not be blocked by the budget that just tripped."""
+        assert FINALIZE_USAGE_LIMITS.per_request_input_tokens_limit is None

--- a/tiger_agent/tasks/handlers/base.py
+++ b/tiger_agent/tasks/handlers/base.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from typing import ClassVar
 
 import logfire
-from pydantic_ai import UsageLimitExceeded
+from pydantic_ai import ModelHTTPError, UsageLimitExceeded
 
 from tiger_agent.agent.constants import USER_DEFINED_EVENTS_ENABLED
 from tiger_agent.agent.tiger_agent import TigerAgent
@@ -25,6 +25,21 @@ from tiger_agent.types import HarnessContext
 
 logger = logging.getLogger(__name__)
 
+# Providers word this differently ("prompt is too long: 1002326 tokens >
+# 1000000 maximum" from Bedrock, "maximum context length" from others), and
+# ModelHTTPError also covers transient 400s that SHOULD be retried -- so match
+# on the message rather than the exception type alone.
+_CONTEXT_OVERFLOW_MARKERS = (
+    "prompt is too long",
+    "maximum context length",
+    "context_length_exceeded",
+)
+
+
+def _is_context_overflow(error: ModelHTTPError) -> bool:
+    """True when the request failed because the prompt did not fit."""
+    return any(marker in str(error).lower() for marker in _CONTEXT_OVERFLOW_MARKERS)
+
 
 class TaskHandler(ABC):
     """Abstract base class for event handlers registered with TaskProcessor.
@@ -34,6 +49,14 @@ class TaskHandler(ABC):
     """
 
     EVENT_TYPES: ClassVar[list[type]]
+
+    EVALUATES_USER_DEFINED_RULES: ClassVar[bool] = True
+    """Whether user-defined rules should be judged after this handler runs.
+
+    Rule evaluation costs an LLM call per candidate rule. Handlers that only
+    mirror data mechanically -- and never invoke the agent themselves -- have
+    nothing a rule could usefully match on, so they opt out.
+    """
 
     def __init__(self, hctx: HarnessContext, agent: TigerAgent) -> None:
         self._hctx = hctx
@@ -89,6 +112,26 @@ class TaskProcessor:
                     text="That request is too large for me to handle in one go. Please split it into smaller batches (for example, fewer items per message) and try again.",
                 )
             return
+        except ModelHTTPError as e:
+            if not _is_context_overflow(e):
+                raise
+            # The prompt exceeded the model's context window. Rebuilding it from
+            # the same inputs produces the same oversized prompt, so requeueing
+            # just burns the attempt budget at full cost. Ack it instead.
+            logger.warning("handler exceeded the model context window", exc_info=e)
+            logfire.warn(
+                "Context window exceeded; not retrying",
+                event_type=type(event).__name__,
+            )
+            if not isinstance(event, (SalesforceBaseEvent, UserDefinedRuleMatch)):
+                await add_reaction(hctx.app.client, event.channel, event.ts, "x")
+                await post_response(
+                    client=hctx.app.client,
+                    channel=event.channel,
+                    thread_ts=event.thread_ts if event.thread_ts else event.ts,
+                    text="That request grew too large for me to finish. Please split it into smaller batches and try again.",
+                )
+            return
         except Exception as e:
             logger.exception("handler failed", exc_info=e)
             if not isinstance(event, (SalesforceBaseEvent, UserDefinedRuleMatch)):
@@ -104,7 +147,11 @@ class TaskProcessor:
             raise
 
         # skip rule evaluation for match events themselves to avoid loops
-        if USER_DEFINED_EVENTS_ENABLED and not isinstance(event, UserDefinedRuleMatch):
+        if (
+            USER_DEFINED_EVENTS_ENABLED
+            and handler.EVALUATES_USER_DEFINED_RULES
+            and not isinstance(event, UserDefinedRuleMatch)
+        ):
             await evaluate_user_defined_rules(
                 pool=hctx.pool,
                 event_type=event.type,

--- a/tiger_agent/tasks/handlers/base.py
+++ b/tiger_agent/tasks/handlers/base.py
@@ -107,9 +107,12 @@ class TaskProcessor:
         except ModelHTTPError as e:
             if not _is_context_overflow(e):
                 raise
-            # The prompt exceeded the model's context window. Rebuilding it from
-            # the same inputs produces the same oversized prompt, so requeueing
-            # just burns the attempt budget at full cost. Ack it instead.
+            # Backstop. AGENT_MAX_REQUEST_INPUT_TOKENS should end a run as
+            # UsageLimitExceeded before the provider ever rejects it, so this
+            # branch only fires if a single turn grew past the headroom or a
+            # model has a smaller window than the limit assumes. Either way the
+            # prompt is a deterministic function of the event, so requeueing
+            # rebuilds it and fails identically -- ack instead of retrying.
             logger.warning("handler exceeded the model context window", exc_info=e)
             logfire.warn(
                 "Context window exceeded; not retrying",

--- a/tiger_agent/tasks/handlers/base.py
+++ b/tiger_agent/tasks/handlers/base.py
@@ -50,14 +50,6 @@ class TaskHandler(ABC):
 
     EVENT_TYPES: ClassVar[list[type]]
 
-    EVALUATES_USER_DEFINED_RULES: ClassVar[bool] = True
-    """Whether user-defined rules should be judged after this handler runs.
-
-    Rule evaluation costs an LLM call per candidate rule. Handlers that only
-    mirror data mechanically -- and never invoke the agent themselves -- have
-    nothing a rule could usefully match on, so they opt out.
-    """
-
     def __init__(self, hctx: HarnessContext, agent: TigerAgent) -> None:
         self._hctx = hctx
         self._agent = agent
@@ -147,11 +139,7 @@ class TaskProcessor:
             raise
 
         # skip rule evaluation for match events themselves to avoid loops
-        if (
-            USER_DEFINED_EVENTS_ENABLED
-            and handler.EVALUATES_USER_DEFINED_RULES
-            and not isinstance(event, UserDefinedRuleMatch)
-        ):
+        if USER_DEFINED_EVENTS_ENABLED and not isinstance(event, UserDefinedRuleMatch):
             await evaluate_user_defined_rules(
                 pool=hctx.pool,
                 event_type=event.type,

--- a/tiger_agent/tasks/handlers/base_specs.py
+++ b/tiger_agent/tasks/handlers/base_specs.py
@@ -38,7 +38,7 @@ def stub_slack_notifications():
         yield
 
 
-def _processor(handler_exc=None, evaluates_rules=True):
+def _processor(handler_exc=None):
     hctx = MagicMock()
     hctx.app.client = MagicMock()
     hctx.pool = MagicMock()
@@ -48,7 +48,6 @@ def _processor(handler_exc=None, evaluates_rules=True):
 
     class Handler(TaskHandler):
         EVENT_TYPES = [_Event]
-        EVALUATES_USER_DEFINED_RULES = evaluates_rules
 
         async def handle(self, task):
             if handler_exc is not None:
@@ -109,42 +108,3 @@ class TestOverflowIsNotRequeued:
         processor, hctx = _processor(handler_exc=UsageLimitExceeded("too much"))
 
         await processor(hctx, _task())  # must not raise
-
-
-class TestRuleEvaluationGate:
-    @patch(
-        "tiger_agent.tasks.handlers.base.evaluate_user_defined_rules", new=AsyncMock()
-    )
-    @patch("tiger_agent.tasks.handlers.base.USER_DEFINED_EVENTS_ENABLED", True)
-    async def test_runs_for_a_normal_handler(self):
-        from tiger_agent.tasks.handlers import base
-
-        processor, hctx = _processor(evaluates_rules=True)
-        await processor(hctx, _task())
-
-        base.evaluate_user_defined_rules.assert_awaited_once()
-
-    @patch(
-        "tiger_agent.tasks.handlers.base.evaluate_user_defined_rules", new=AsyncMock()
-    )
-    @patch("tiger_agent.tasks.handlers.base.USER_DEFINED_EVENTS_ENABLED", True)
-    async def test_skipped_when_the_handler_opts_out(self):
-        """A mechanical mirror has nothing a rule could usefully match on."""
-        from tiger_agent.tasks.handlers import base
-
-        processor, hctx = _processor(evaluates_rules=False)
-        await processor(hctx, _task())
-
-        base.evaluate_user_defined_rules.assert_not_awaited()
-
-    def test_the_feed_item_handler_opts_out(self):
-        from tiger_agent.tasks.handlers.salesforce_feed_item import (
-            SalesforceFeedItemHandler,
-        )
-
-        assert SalesforceFeedItemHandler.EVALUATES_USER_DEFINED_RULES is False
-
-    def test_handlers_evaluate_rules_by_default(self):
-        from tiger_agent.tasks.handlers.slack import SlackTaskHandler
-
-        assert SlackTaskHandler.EVALUATES_USER_DEFINED_RULES is True

--- a/tiger_agent/tasks/handlers/base_specs.py
+++ b/tiger_agent/tasks/handlers/base_specs.py
@@ -1,0 +1,150 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic_ai import ModelHTTPError, UsageLimitExceeded
+
+from tiger_agent.tasks.handlers.base import (
+    TaskHandler,
+    TaskProcessor,
+    _is_context_overflow,
+)
+
+BEDROCK_OVERFLOW = (
+    "status_code: 400, model_name: anthropic/claude-opus-4-8, body: "
+    "{'message': 'Provider returned error', 'code': 400, 'metadata': "
+    "{'raw': '{\"message\":\"prompt is too long: 1002326 tokens > 1000000 maximum\"}'}}"
+)
+
+
+class _Event:
+    """A user-facing event, so the notification branches are exercised."""
+
+    type = "app_mention"
+    channel = "C123"
+    ts = "1.0"
+    thread_ts = None
+
+    def model_dump(self) -> dict:
+        return {"type": self.type, "subtype": "test"}
+
+
+@pytest.fixture(autouse=True)
+def stub_slack_notifications():
+    """These paths post to Slack; the logic under test is the control flow."""
+    with (
+        patch("tiger_agent.tasks.handlers.base.add_reaction", new=AsyncMock()),
+        patch("tiger_agent.tasks.handlers.base.post_response", new=AsyncMock()),
+    ):
+        yield
+
+
+def _processor(handler_exc=None, evaluates_rules=True):
+    hctx = MagicMock()
+    hctx.app.client = MagicMock()
+    hctx.pool = MagicMock()
+
+    agent = MagicMock()
+    agent.max_attempts = 3
+
+    class Handler(TaskHandler):
+        EVENT_TYPES = [_Event]
+        EVALUATES_USER_DEFINED_RULES = evaluates_rules
+
+        async def handle(self, task):
+            if handler_exc is not None:
+                raise handler_exc
+
+    processor = TaskProcessor(hctx, agent)
+    processor.register(_Event, Handler(hctx, agent))
+    return processor, hctx
+
+
+def _task():
+    task = MagicMock()
+    task.event = _Event()
+    task.attempts = 1
+    return task
+
+
+class TestContextOverflowDetection:
+    def test_recognises_the_bedrock_wording(self):
+        assert _is_context_overflow(ModelHTTPError(400, "m", body=BEDROCK_OVERFLOW))
+
+    @pytest.mark.parametrize(
+        "body",
+        ["maximum context length is 200000 tokens", "context_length_exceeded"],
+    )
+    def test_recognises_other_provider_wordings(self, body):
+        assert _is_context_overflow(ModelHTTPError(400, "m", body=body))
+
+    def test_does_not_match_an_unrelated_400(self):
+        """ModelHTTPError also covers transient 400s that should still retry."""
+        err = ModelHTTPError(400, "m", body="{'message': 'Could not process image'}")
+
+        assert not _is_context_overflow(err)
+
+
+class TestOverflowIsNotRequeued:
+    async def test_overflow_is_acked_rather_than_raised(self):
+        """Rebuilding the same prompt overflows again -- retrying burns budget."""
+        exc = ModelHTTPError(400, "m", body=BEDROCK_OVERFLOW)
+        processor, hctx = _processor(handler_exc=exc)
+
+        await processor(hctx, _task())  # must not raise
+
+    async def test_an_unrelated_model_error_still_requeues(self):
+        exc = ModelHTTPError(400, "m", body="{'message': 'Could not process image'}")
+        processor, hctx = _processor(handler_exc=exc)
+
+        with pytest.raises(ModelHTTPError):
+            await processor(hctx, _task())
+
+    async def test_other_failures_still_requeue(self):
+        processor, hctx = _processor(handler_exc=RuntimeError("boom"))
+
+        with pytest.raises(RuntimeError):
+            await processor(hctx, _task())
+
+    async def test_usage_limit_is_still_acked(self):
+        processor, hctx = _processor(handler_exc=UsageLimitExceeded("too much"))
+
+        await processor(hctx, _task())  # must not raise
+
+
+class TestRuleEvaluationGate:
+    @patch(
+        "tiger_agent.tasks.handlers.base.evaluate_user_defined_rules", new=AsyncMock()
+    )
+    @patch("tiger_agent.tasks.handlers.base.USER_DEFINED_EVENTS_ENABLED", True)
+    async def test_runs_for_a_normal_handler(self):
+        from tiger_agent.tasks.handlers import base
+
+        processor, hctx = _processor(evaluates_rules=True)
+        await processor(hctx, _task())
+
+        base.evaluate_user_defined_rules.assert_awaited_once()
+
+    @patch(
+        "tiger_agent.tasks.handlers.base.evaluate_user_defined_rules", new=AsyncMock()
+    )
+    @patch("tiger_agent.tasks.handlers.base.USER_DEFINED_EVENTS_ENABLED", True)
+    async def test_skipped_when_the_handler_opts_out(self):
+        """A mechanical mirror has nothing a rule could usefully match on."""
+        from tiger_agent.tasks.handlers import base
+
+        processor, hctx = _processor(evaluates_rules=False)
+        await processor(hctx, _task())
+
+        base.evaluate_user_defined_rules.assert_not_awaited()
+
+    def test_the_feed_item_handler_opts_out(self):
+        from tiger_agent.tasks.handlers.salesforce_feed_item import (
+            SalesforceFeedItemHandler,
+        )
+
+        assert SalesforceFeedItemHandler.EVALUATES_USER_DEFINED_RULES is False
+
+    def test_handlers_evaluate_rules_by_default(self):
+        from tiger_agent.tasks.handlers.slack import SlackTaskHandler
+
+        assert SlackTaskHandler.EVALUATES_USER_DEFINED_RULES is True

--- a/tiger_agent/tasks/handlers/salesforce_feed_item.py
+++ b/tiger_agent/tasks/handlers/salesforce_feed_item.py
@@ -19,10 +19,6 @@ class SalesforceFeedItemHandler(TaskHandler):
 
     EVENT_TYPES = [SalesforceFeedItemEvent]
 
-    # This handler mirrors a Salesforce feed item into Slack and never invokes
-    # the agent, so there is nothing for a user-defined rule to judge.
-    EVALUATES_USER_DEFINED_RULES = False
-
     @logfire.instrument("SalesforceFeedItemHandler.handle", extract_args=["task"])
     async def handle(self, task: Task) -> None:
         hctx = self._hctx

--- a/tiger_agent/tasks/handlers/salesforce_feed_item.py
+++ b/tiger_agent/tasks/handlers/salesforce_feed_item.py
@@ -19,6 +19,10 @@ class SalesforceFeedItemHandler(TaskHandler):
 
     EVENT_TYPES = [SalesforceFeedItemEvent]
 
+    # This handler mirrors a Salesforce feed item into Slack and never invokes
+    # the agent, so there is nothing for a user-defined rule to judge.
+    EVALUATES_USER_DEFINED_RULES = False
+
     @logfire.instrument("SalesforceFeedItemHandler.handle", extract_args=["task"])
     async def handle(self, task: Task) -> None:
         hctx = self._hctx


### PR DESCRIPTION
## Problem

A run was observed dying on:

```
prompt is too long: 1002326 tokens > 1000000 maximum
```

A provider 400 is the worst available shape for this failure. The oversized request is **billed**, nothing is salvaged, and because the prompt is a deterministic function of the event, the generic `except Exception` re-raises and the worker rebuilds the identical prompt up to `max_attempts=3` times. For Salesforce events there is no user-visible signal on any attempt.

## Approach: stop before the wall, don't just decline to retry

`UsageLimitExceeded` already has a good story — the warner counts down toward it, `run_and_return_partial` converts it into a partial answer, and the handler acks it without requeueing. Context overflow had none of that, purely because it arrives as a different exception type.

`per_request_input_tokens_limit` closes that gap. pydantic-ai checks it in `_handle_model_response` against **each response's input tokens as they arrive**. Context grows monotonically, so catching *"this turn was 850K"* ends the run before the next turn would breach 1M — and it raises `UsageLimitExceeded`, so overflow now routes into the path that already works rather than needing one of its own.

### The resulting layering

| At | What happens |
|---|---|
| 560K | Warner injects a converge-now message (`0.7 × 800K`) |
| 720K | Compaction attempts (`0.9 × 800K`) |
| **850K** | **`UsageLimitExceeded` → partial answer → ack** |
| 1M | Provider wall — never reached |

### Why 850K

Above the compaction trigger, so context management gets first attempt. Far enough below a 1M window that one more turn cannot clear it — a single tool result is capped near 50K by `ContextManagerCapability` and again by `MAX_TOOL_RESULT_CHARS`. And only **39 of 20,652 calls** in a six-day sample exceeded 720K at all, so routine work never sees it.

## The `ModelHTTPError` branch stays, as a backstop

It now fires only if a single turn grows past the headroom, or a model has a smaller window than the limit assumes. Still worth catching — a 400 costs a full billed request and three rebuilds — but it is no longer the plan.

It matches the provider **message**, not the exception type: `ModelHTTPError` also covers transient 400s that *should* retry (`Could not process image` appeared 70 times in the sample window). Three markers, since providers word it differently.

## Testing

`agent/limits_specs.py` — 7 new specs asserting the ceiling is set, leaves ≥100K headroom under a 1M window, sits above the compaction trigger, warns before it fires, raises the exception the fallback already handles, passes a normal p95-sized request, and does **not** apply to the finalize pass (which must not be blocked by the budget that just tripped).

`tasks/handlers/base_specs.py` — 8 specs for the backstop: three provider wordings detected, an unrelated 400 explicitly not matched, overflow acked, unrelated `ModelHTTPError` still requeues, other exceptions still requeue, `UsageLimitExceeded` still acked.

Suite **149 passing**. Rebased onto current `main` (includes #277, #278).

## Scope notes

- The `EVALUATES_USER_DEFINED_RULES` opt-out originally bundled here was removed on review — separate concern, separate PR.
- **This does not cover the investigator.** `SubAgent` carries its own `usage_limits` and currently gets pydantic-ai's defaults, so it has no per-request ceiling. Its observed max is 835K — under 1M, but unprotected. That is A1's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)