### PR TITLE
Close the two delegation loopholes that kept research inline

### DIFF
--- a/tiger_agent/prompts/system_prompt.md
+++ b/tiger_agent/prompts/system_prompt.md
@@ -76,7 +76,8 @@ When a tool fails, the shape of the failure tells you what to do next. Do NOT de
 
 **Do not delegate when:**
 
-- The answer is a single structured lookup by known ID (`salesforce_get_case_details`, `salesforce_get_account_details`, `get_releases`, fetch-by-permalink). These are cheap; delegating adds a full sub-agent round-trip for no benefit.
+- The answer is **one** structured lookup by known ID (`salesforce_get_case_details`, `salesforce_get_account_details`, `get_releases`, fetch-by-permalink). A single such call is cheap; delegating adds a sub-agent round-trip for no benefit.
+  - This exemption is per call, not per tool. If you are about to look up *a list* of things — every related case, every attachment, every user on an account — that is a fan-out, not a lookup. Delegate it as one task ("summarise these five cases") and let the sub-agent absorb the payloads. Runs that treated a repeated cheap lookup as still-cheap reached 82 calls to one tool in a single context.
 - The result of one search *is* your final answer and won't feed into further exploration.
 - You already have the information in your context.
 - The task can't be phrased as one self-contained question.
@@ -90,6 +91,8 @@ Skills usually run better inside a sub-agent than in your own context. Pass the 
 If a skill has independent workflow sections (e.g. metric investigation vs. GitHub SDC search vs. Slack thread search), delegate each section as its own `delegate_task` call so they run in parallel.
 
 Run a skill inline only when its output *is* your response — when you're at the final step and the skill produces the exact artifact you're about to post (a structured notification, a draft message, a summary you'll return verbatim). If you're still gathering information that will feed into a later response, delegate.
+
+**This exemption covers the formatting step only, and it does not travel.** A skill that composes your final answer may itself invoke research skills; those still get delegated. `salesforce-case-information-gathering`, `customer-health-check` and `service-investigation` must **always** run inside `delegate_task`, even when you reached them from a skill you are running inline. Composing the notification in your context is fine. Gathering the material for it in your context is not — that is how a single case ends up making a hundred tool calls against one conversation.
 
 **Response Formatting:**
 Respond in valid Markdown format, following these rules:


### PR DESCRIPTION
## Problem

The delegation architecture exists so that iterative tool work and large payloads stay out of the coordinator's context. **In the worst traces it was never used.**

- 150 turns in a single `gen_ai.conversation.id` with **zero** `delegate_task` calls — verified on 4/4 worst traces on 20 Aug and again on 24 Aug
- Across six days, delegation fired in **~44% of Opus traces, averaging 1.3 calls** — for skills whose happy path implies 30–50 tool calls

Two rules in `system_prompt.md` combine to exempt exactly the most expensive path.

## Loophole 1 — "cheap" doesn't survive repetition

> *"The answer is a single structured lookup by known ID… These are cheap; delegating adds a full sub-agent round-trip for no benefit."*

True for one call. The observed runs applied the same reasoning to **82 `get_case_summary` calls in one context** — including the same case fetched five times byte-for-byte — because each individual call was, indeed, a cheap lookup by known ID.

The exemption is now explicitly **per call, not per tool**, with fan-out over a *list* named as the case that must be delegated.

## Loophole 2 — the inline exception travelled

> *"Run a skill inline only when its output* is *your response… (a structured notification, a draft message…)"*

`salesforce-new-case-notification` produces exactly a structured notification. So a rule written for the **final formatting step** authorised running its entire three-level research fan-out inline — `salesforce-case-information-gathering` at depth 1, `service-investigation` and `tsdb-instance-health-check` at depth 2, `thanos-range-query` and `elasticsearch-log-inspection` at depth 3.

The exemption now covers formatting only and **explicitly does not travel** to skills invoked beneath it. `salesforce-case-information-gathering`, `customer-health-check` and `service-investigation` must always run inside `delegate_task`, even when reached from a skill running inline.

## Scope

Prompt-only, no code. Easily reverted if delegation proves too aggressive.

Verified the Jinja template still parses; suite unchanged at **110 passing**.

## How to tell if it worked

Two numbers with current baselines:

- `delegate_task` rate — currently **~44%** of Opus traces at 1.3 calls each
- coordinator p95 context — currently **324,132 tokens** (`gen_ai.agent.name = 'agent'`)

Both should move. If the first rises and the second falls, the boundary is finally doing its job.

## Related

This is the prerequisite for two open questions. The investigator is currently **26% of spend** and runs Opus inherited from the parent; whether it should move to a cheaper model only becomes answerable once delegation actually carries the tool iteration. Same for whether the coordinator's own context stays small enough to justify Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)