### PR TITLE
[AGE-586] Implement Slack Workflow initiated new case action

### DIFF
--- a/slack-manifest.json
+++ b/slack-manifest.json
@@ -41,7 +41,8 @@
         "files:read",
         "files:write",
         "team:read",
-        "usergroups:read"
+        "usergroups:read",
+        "workflow.steps:execute"
       ]
     }
   },
@@ -51,6 +52,7 @@
         "app_mention",
         "message.channels",
         "message.im",
+        "workflow_step_execute",
         "function_executed"
       ]
     },
@@ -60,5 +62,28 @@
     "org_deploy_enabled": false,
     "socket_mode_enabled": true,
     "token_rotation_enabled": false
+  },
+  "functions": {
+    "create_case": {
+      "title": "Create Case",
+      "description": "Executes a custom Python backend logic step",
+      "input_parameters": {
+        "UserId": {
+          "type": "string",
+          "title": "User Id",
+          "description": "The user who initiated the action",
+          "is_required": true,
+          "name": "UserId"
+        },
+        "ChannelId": {
+          "type": "string",
+          "title": "Channel Id",
+          "description": "The channel where the workflow was triggered",
+          "is_required": true,
+          "name": "ChannelId"
+        }
+      },
+      "output_parameters": {}
+    }
   }
 }

--- a/tiger_agent/agent/tools.py
+++ b/tiger_agent/agent/tools.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
+import asyncio
 import re
 from typing import Any
 
 from pydantic_ai import BinaryContent, Tool
 
+from tiger_agent.agent.constants import USER_DEFINED_EVENTS_ENABLED
 from tiger_agent.db.utils import (
     delete_user_defined_rule,
+    get_salesforce_account_id_for_channel,
     insert_user_defined_rule,
     list_user_defined_rules,
     user_is_admin,
 )
-from tiger_agent.agent.constants import USER_DEFINED_EVENTS_ENABLED
 from tiger_agent.events import EVENT_TYPE_OPTIONS, EVENT_TYPES_BY_NAME
 from tiger_agent.logfire.constants import LOGFIRE_READ_TOKEN
 from tiger_agent.logfire.utils import (
@@ -23,24 +25,30 @@ from tiger_agent.logfire.utils import (
 )
 from tiger_agent.org_calendar.utils import get_calender_events
 from tiger_agent.salesforce.types import (
+    ServiceRecord,
     UserDefinedRule,
 )
 from tiger_agent.salesforce.utils import (
     EXT_TO_MIME,
     download_content_version_url,
+    get_services_for_account,
 )
-from tiger_agent.slack.types import SlackBaseEvent
+from tiger_agent.slack.types import ChannelInfo, SlackBaseEvent
 from tiger_agent.slack.utils import (
+    channel_is_external,
     download_slack_hosted_file,
     find_user_group,
     get_user_ids_in_channel,
     get_user_ids_in_user_group,
+    send_new_salesforce_case_workflow_form,
 )
 from tiger_agent.tasks.types import Task
 from tiger_agent.types import HarnessContext
 
 
-def create_tools(hctx: HarnessContext, task: Task) -> list[Tool]:
+def create_tools(
+    hctx: HarnessContext, task: Task, channel_info: ChannelInfo
+) -> list[Tool]:
     event = task.event
 
     def _download_salesforce_hosted_file(
@@ -185,6 +193,69 @@ def create_tools(hctx: HarnessContext, task: Task) -> list[Tool]:
         if not await user_is_admin(pool=hctx.pool, user_id=event.user):
             return "This tool can only be used by admins."
         return await find_errors(lookback_hours=lookback_hours, limit=limit)
+
+    async def _show_salesforce_case_form() -> str:
+        assert isinstance(event, SlackBaseEvent)
+        if not event.user:
+            return "Cannot show case form: no user is associated with this event."
+
+        account_id = await get_salesforce_account_id_for_channel(
+            pool=hctx.pool, channel_id=event.channel
+        )
+        if not account_id:
+            return (
+                "This Slack channel is not linked to a Salesforce account, "
+                "so I cannot open a support case from here. "
+                "Please contact an admin to link this channel to a Salesforce account."
+            )
+
+        services: list[ServiceRecord] | None = None
+        if hctx.salesforce_client:
+            services = await asyncio.get_running_loop().run_in_executor(
+                None,
+                lambda: get_services_for_account(
+                    salesforce_client=hctx.salesforce_client, account_id=account_id
+                ),
+            )
+
+        try:
+            await send_new_salesforce_case_workflow_form(
+                client=hctx.app.client,
+                channel=event.channel,
+                user=event.user,
+                services=services,
+            )
+        except Exception as e:
+            return f"Sorry, I couldn't display the case creation form right now: {e}"
+
+        return (
+            "I've sent you an ephemeral form to open a new support case. "
+            "Only you can see it — fill it out and submit when ready."
+        )
+
+    # if the handling of this event has a destination output in a customer-facing
+    # channel, we do not want to expose all of the available tooling, but just a list of
+    # tools that are deemed customer facing.
+    if channel_is_external(channel_info=channel_info):
+        return [
+            Tool(
+                _show_salesforce_case_form,
+                takes_ctx=False,
+                name="show_salesforce_case_form",
+                description=(
+                    "Show an ephemeral form in the current Slack channel for creating a new Salesforce support case. "
+                    "This form is only visible to the requesting user. The form dynamically populates a service/project "
+                    "dropdown based on the Salesforce account linked to this channel.\n\n"
+                    "Use when the user asks to:\n"
+                    "- open a support ticket/case\n"
+                    "- create a new support case\n"
+                    "- report an issue that needs a ticket\n"
+                    "- file a bug or problem report\n"
+                    "- get help with a technical issue that should be tracked in Salesforce\n\n"
+                    "If this channel is not linked to a Salesforce account, the tool returns an explanatory message."
+                ),
+            ),
+        ]
 
     return [
         Tool(

--- a/tiger_agent/agent/tools.py
+++ b/tiger_agent/agent/tools.py
@@ -47,7 +47,10 @@ from tiger_agent.types import HarnessContext
 
 
 def create_tools(
-    hctx: HarnessContext, task: Task, channel_info: ChannelInfo
+    hctx: HarnessContext,
+    task: Task,
+    channel_info: ChannelInfo,
+    channel_is_linked_to_salesforce_account: bool = False,
 ) -> list[Tool]:
     event = task.event
 
@@ -237,6 +240,8 @@ def create_tools(
     # channel, we do not want to expose all of the available tooling, but just a list of
     # tools that are deemed customer facing.
     if channel_is_external(channel_info=channel_info):
+        if not channel_is_linked_to_salesforce_account:
+            return []
         return [
             Tool(
                 _show_salesforce_case_form,

--- a/tiger_agent/agent/tools_specs.py
+++ b/tiger_agent/agent/tools_specs.py
@@ -69,30 +69,73 @@ def disable_feature_flags(monkeypatch):
 
 
 class TestCreateToolsExternalChannel:
-    def test_ext_shared_channel_returns_only_case_form_tool(self, hctx):
+    def test_ext_shared_channel_linked_to_sf_returns_only_case_form_tool(self, hctx):
         channel_info = _make_channel_info(is_ext_shared=True, is_shared=False)
-        tool_list = create_tools(hctx, _make_slack_task(), channel_info)
-        assert len(tool_list) == 1
-        assert tool_list[0].name == "show_salesforce_case_form"
+        tool_list = create_tools(
+            hctx,
+            _make_slack_task(),
+            channel_info,
+            channel_is_linked_to_salesforce_account=True,
+        )
+        assert [t.name for t in tool_list] == ["show_salesforce_case_form"]
 
-    def test_shared_channel_returns_only_case_form_tool(self, hctx):
+    def test_shared_channel_linked_to_sf_returns_only_case_form_tool(self, hctx):
         channel_info = _make_channel_info(is_ext_shared=False, is_shared=True)
+        tool_list = create_tools(
+            hctx,
+            _make_slack_task(),
+            channel_info,
+            channel_is_linked_to_salesforce_account=True,
+        )
+        assert [t.name for t in tool_list] == ["show_salesforce_case_form"]
+
+    def test_ext_shared_channel_not_linked_returns_no_tools(self, hctx):
+        channel_info = _make_channel_info(is_ext_shared=True, is_shared=False)
+        tool_list = create_tools(
+            hctx,
+            _make_slack_task(),
+            channel_info,
+            channel_is_linked_to_salesforce_account=False,
+        )
+        assert tool_list == []
+
+    def test_shared_channel_not_linked_returns_no_tools(self, hctx):
+        channel_info = _make_channel_info(is_ext_shared=False, is_shared=True)
+        tool_list = create_tools(
+            hctx,
+            _make_slack_task(),
+            channel_info,
+            channel_is_linked_to_salesforce_account=False,
+        )
+        assert tool_list == []
+
+    def test_external_channel_defaults_to_no_tools_when_link_flag_omitted(self, hctx):
+        channel_info = _make_channel_info(is_ext_shared=True)
         tool_list = create_tools(hctx, _make_slack_task(), channel_info)
-        assert len(tool_list) == 1
-        assert tool_list[0].name == "show_salesforce_case_form"
+        assert tool_list == []
 
     def test_external_channel_ignores_feature_flags(self, hctx, monkeypatch):
         monkeypatch.setattr(tools_module, "USER_DEFINED_EVENTS_ENABLED", True)
         monkeypatch.setattr(tools_module, "LOGFIRE_READ_TOKEN", "token")
         channel_info = _make_channel_info(is_ext_shared=True)
-        tool_list = create_tools(hctx, _make_slack_task(), channel_info)
+        tool_list = create_tools(
+            hctx,
+            _make_slack_task(),
+            channel_info,
+            channel_is_linked_to_salesforce_account=True,
+        )
         assert [t.name for t in tool_list] == ["show_salesforce_case_form"]
 
     def test_external_channel_with_non_slack_event_still_returns_only_case_form(
         self, hctx
     ):
         channel_info = _make_channel_info(is_ext_shared=True)
-        tool_list = create_tools(hctx, _make_non_slack_task(), channel_info)
+        tool_list = create_tools(
+            hctx,
+            _make_non_slack_task(),
+            channel_info,
+            channel_is_linked_to_salesforce_account=True,
+        )
         assert [t.name for t in tool_list] == ["show_salesforce_case_form"]
 
 
@@ -107,6 +150,29 @@ class TestCreateToolsInternalChannel:
         assert "attach_file_to_slack_thread" in names
         assert "get_user_ids_in_user_group" in names
         assert "get_user_ids_in_channel" in names
+
+    def test_internal_channel_ignores_salesforce_link_flag(self, hctx):
+        channel_info = _make_channel_info(is_ext_shared=False, is_shared=False)
+        linked_names = [
+            t.name
+            for t in create_tools(
+                hctx,
+                _make_slack_task(),
+                channel_info,
+                channel_is_linked_to_salesforce_account=True,
+            )
+        ]
+        unlinked_names = [
+            t.name
+            for t in create_tools(
+                hctx,
+                _make_slack_task(),
+                channel_info,
+                channel_is_linked_to_salesforce_account=False,
+            )
+        ]
+        assert linked_names == unlinked_names
+        assert "show_salesforce_case_form" not in linked_names
 
     def test_user_defined_rule_tools_gated_off_by_default(self, hctx):
         channel_info = _make_channel_info()

--- a/tiger_agent/agent/tools_specs.py
+++ b/tiger_agent/agent/tools_specs.py
@@ -1,0 +1,153 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from tiger_agent.agent import tools as tools_module
+from tiger_agent.agent.tools import create_tools
+from tiger_agent.salesforce.types import SalesforceCreateNewCaseEvent
+from tiger_agent.slack.types import ChannelInfo, SlackAppMentionEvent
+from tiger_agent.tasks.types import Task
+
+
+def _make_channel_info(**overrides) -> ChannelInfo:
+    defaults: dict = {"id": "C_CHAN", "name": "general"}
+    defaults.update(overrides)
+    return ChannelInfo(**defaults)
+
+
+def _make_task(event) -> Task:
+    return Task(
+        id=1,
+        event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        attempts=0,
+        vt=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        claimed=[],
+        event=event,
+    )
+
+
+def _make_slack_task() -> Task:
+    return _make_task(
+        SlackAppMentionEvent(
+            ts="1700000000.000100",
+            text="<@U_BOT> hi",
+            channel="C_CHAN",
+            event_ts="1700000000.000100",
+            user="U_USER",
+        )
+    )
+
+
+def _make_non_slack_task() -> Task:
+    return _make_task(
+        SalesforceCreateNewCaseEvent(
+            subject="disk full",
+            description="prod is down",
+            user="U_USER",
+            channel="C_CHAN",
+            severity="High",
+            project_id=None,
+            service_id=None,
+        )
+    )
+
+
+@pytest.fixture
+def hctx():
+    return MagicMock()
+
+
+@pytest.fixture(autouse=True)
+def disable_feature_flags(monkeypatch):
+    """Default the optional tool groups off so a baseline test knows what to expect.
+
+    Individual tests re-patch these to True to exercise the enabled paths.
+    """
+    monkeypatch.setattr(tools_module, "USER_DEFINED_EVENTS_ENABLED", False)
+    monkeypatch.setattr(tools_module, "LOGFIRE_READ_TOKEN", "")
+
+
+class TestCreateToolsExternalChannel:
+    def test_ext_shared_channel_returns_only_case_form_tool(self, hctx):
+        channel_info = _make_channel_info(is_ext_shared=True, is_shared=False)
+        tool_list = create_tools(hctx, _make_slack_task(), channel_info)
+        assert len(tool_list) == 1
+        assert tool_list[0].name == "show_salesforce_case_form"
+
+    def test_shared_channel_returns_only_case_form_tool(self, hctx):
+        channel_info = _make_channel_info(is_ext_shared=False, is_shared=True)
+        tool_list = create_tools(hctx, _make_slack_task(), channel_info)
+        assert len(tool_list) == 1
+        assert tool_list[0].name == "show_salesforce_case_form"
+
+    def test_external_channel_ignores_feature_flags(self, hctx, monkeypatch):
+        monkeypatch.setattr(tools_module, "USER_DEFINED_EVENTS_ENABLED", True)
+        monkeypatch.setattr(tools_module, "LOGFIRE_READ_TOKEN", "token")
+        channel_info = _make_channel_info(is_ext_shared=True)
+        tool_list = create_tools(hctx, _make_slack_task(), channel_info)
+        assert [t.name for t in tool_list] == ["show_salesforce_case_form"]
+
+    def test_external_channel_with_non_slack_event_still_returns_only_case_form(
+        self, hctx
+    ):
+        channel_info = _make_channel_info(is_ext_shared=True)
+        tool_list = create_tools(hctx, _make_non_slack_task(), channel_info)
+        assert [t.name for t in tool_list] == ["show_salesforce_case_form"]
+
+
+class TestCreateToolsInternalChannel:
+    def test_internal_slack_event_returns_base_tool_set(self, hctx):
+        channel_info = _make_channel_info(is_ext_shared=False, is_shared=False)
+        names = [t.name for t in create_tools(hctx, _make_slack_task(), channel_info)]
+        assert "show_salesforce_case_form" not in names
+        assert "download_slack_hosted_file" in names
+        assert "download_salesforce_hosted_file" in names
+        assert "get_org_calendar_events" in names
+        assert "attach_file_to_slack_thread" in names
+        assert "get_user_ids_in_user_group" in names
+        assert "get_user_ids_in_channel" in names
+
+    def test_user_defined_rule_tools_gated_off_by_default(self, hctx):
+        channel_info = _make_channel_info()
+        names = [t.name for t in create_tools(hctx, _make_slack_task(), channel_info)]
+        assert "list_user_defined_rules" not in names
+        assert "delete_user_defined_rule" not in names
+        assert "create_user_defined_rule" not in names
+
+    def test_user_defined_rule_tools_included_when_flag_on(self, hctx, monkeypatch):
+        monkeypatch.setattr(tools_module, "USER_DEFINED_EVENTS_ENABLED", True)
+        channel_info = _make_channel_info()
+        names = [t.name for t in create_tools(hctx, _make_slack_task(), channel_info)]
+        assert "list_user_defined_rules" in names
+        assert "delete_user_defined_rule" in names
+        assert "create_user_defined_rule" in names
+
+    def test_logfire_tools_gated_off_by_default(self, hctx):
+        channel_info = _make_channel_info()
+        names = [t.name for t in create_tools(hctx, _make_slack_task(), channel_info)]
+        assert "get_tool_calls_for_event" not in names
+        assert "get_logs_for_event" not in names
+        assert "get_log_by_id" not in names
+        assert "find_errors" not in names
+
+    def test_logfire_tools_included_when_token_set(self, hctx, monkeypatch):
+        monkeypatch.setattr(tools_module, "LOGFIRE_READ_TOKEN", "some-token")
+        channel_info = _make_channel_info()
+        names = [t.name for t in create_tools(hctx, _make_slack_task(), channel_info)]
+        assert "get_tool_calls_for_event" in names
+        assert "get_logs_for_event" in names
+        assert "get_log_by_id" in names
+        assert "find_errors" in names
+
+    def test_non_slack_event_omits_slack_event_dependent_tools(self, hctx, monkeypatch):
+        monkeypatch.setattr(tools_module, "USER_DEFINED_EVENTS_ENABLED", True)
+        monkeypatch.setattr(tools_module, "LOGFIRE_READ_TOKEN", "some-token")
+        channel_info = _make_channel_info()
+        names = [t.name for t in create_tools(hctx, _make_non_slack_task(), channel_info)]
+        # The always-on, event-agnostic tools remain.
+        assert names == [
+            "download_slack_hosted_file",
+            "download_salesforce_hosted_file",
+            "get_org_calendar_events",
+        ]

--- a/tiger_agent/agent/utils.py
+++ b/tiger_agent/agent/utils.py
@@ -36,6 +36,7 @@ from tiger_agent.salesforce.types import (
     SalesforceBaseEvent,
 )
 from tiger_agent.slack.utils import (
+    fetch_channel_info,
     fetch_thread_messages,
     fetch_user_info,
 )
@@ -153,6 +154,10 @@ async def create_agent_and_context(
 ) -> AgentAndContext:
     event = task.event
 
+    destination_channel_info = await fetch_channel_info(
+        client=hctx.app.client, channel_id=channel_to_respond
+    )
+
     all_mcp_servers = agent.mcp_loader()
     agent.augment_mcp_servers(all_mcp_servers)
 
@@ -192,7 +197,7 @@ async def create_agent_and_context(
     )
 
     toolsets = [_build_toolset(mcp_config) for mcp_config in mcp_servers.values()]
-    tools = create_tools(hctx=hctx, task=task)
+    tools = create_tools(hctx=hctx, task=task, channel_info=destination_channel_info)
 
     agent = Agent(
         capabilities=[

--- a/tiger_agent/agent/utils.py
+++ b/tiger_agent/agent/utils.py
@@ -29,6 +29,7 @@ from tiger_agent.agent.types import (
     ExtraContextDict,
     SpamAssessment,
 )
+from tiger_agent.db.utils import get_salesforce_account_id_for_channel
 from tiger_agent.mcp.types import McpConfig
 from tiger_agent.mcp.utils import filter_mcp_servers
 from tiger_agent.salesforce.types import (
@@ -197,7 +198,17 @@ async def create_agent_and_context(
     )
 
     toolsets = [_build_toolset(mcp_config) for mcp_config in mcp_servers.values()]
-    tools = create_tools(hctx=hctx, task=task, channel_info=destination_channel_info)
+    channel_is_linked_to_salesforce_account = bool(
+        await get_salesforce_account_id_for_channel(
+            pool=hctx.pool, channel_id=channel_to_respond
+        )
+    )
+    tools = create_tools(
+        hctx=hctx,
+        task=task,
+        channel_info=destination_channel_info,
+        channel_is_linked_to_salesforce_account=channel_is_linked_to_salesforce_account,
+    )
 
     agent = Agent(
         capabilities=[

--- a/tiger_agent/listeners/slack.py
+++ b/tiger_agent/listeners/slack.py
@@ -6,6 +6,8 @@ from typing import Any
 import logfire
 from slack_bolt.adapter.socket_mode.websockets import AsyncSocketModeHandler
 from slack_bolt.context.ack.async_ack import AsyncAck
+from slack_bolt.context.complete.async_complete import AsyncComplete
+from slack_bolt.context.fail.async_fail import AsyncFail
 from slack_bolt.context.respond.async_respond import AsyncRespond
 
 from tiger_agent.db.utils import (
@@ -25,6 +27,7 @@ from tiger_agent.salesforce.utils import (
 )
 from tiger_agent.slack.constants import (
     CONFIRM_PROACTIVE_PROMPT,
+    CREATE_CASE_FUNCTION_ID,
     FEEDBACK_FORM_SUBMIT,
     FEEDBACK_FORM_TRIGGER,
     NEW_SALESFORCE_CASE_WORKFLOW_FORM_CANCEL,
@@ -109,6 +112,10 @@ class SlackListener(Listener):
         self._app.event("message")(self._on_message)
         self._app.command(re.compile(r"\/.*"))(self._on_slack_admin_command)
         self._app.event("app_mention")(self._on_slack_event)
+
+        self._app.function(CREATE_CASE_FUNCTION_ID)(
+            self._handle_create_support_case_function
+        )
 
         handler = AsyncSocketModeHandler(self._app, app_token=SLACK_APP_TOKEN)
         tasks.create_task(self._run_socket_mode(handler))
@@ -312,6 +319,65 @@ class SlackListener(Listener):
             user=user,
             services=services_and_projects,
         )
+
+    async def _handle_create_support_case_function(
+        self, inputs: dict, fail: AsyncFail, complete: AsyncComplete
+    ):
+        """This is the handler for the Create Case workflow step/function call initiated by the Slack App.
+        The use case that this is satisifying is to give customers the ability to click a Create Case workflow button
+        Pinned onto the message input bar in our external Slack channel for them. The input payload should be configured
+        to include the intiator's user id and the channel in which they originated it from. Once we have that, we will present
+        a create case form to the initiator in the form of an ephemeral message that only they can see.
+        """
+
+        user_id = inputs.get("UserId", {})
+        channel_id = inputs.get("ChannelId", {})
+
+        if not user_id or not channel_id:
+            logfire.error(
+                "Custom workflow missing required inputs",
+                user=user_id,
+                channel=channel_id,
+                inputs=inputs,
+            )
+            await fail(
+                error="Missing required inputs: UserId or ChannelId",
+            )
+            return
+
+        account_id = await get_salesforce_account_id_for_channel(
+            self._pool, channel_id=channel_id
+        )
+
+        if not account_id:
+            logfire.warning(
+                "Custom workflow triggered in channel without Salesforce linkage",
+                channel=channel_id,
+            )
+            await fail(
+                error="This channel is not linked to a Salesforce account.",
+            )
+            return
+
+        services = None
+        if self._hctx.salesforce_client:
+            services = get_services_for_account(
+                self._hctx.salesforce_client, account_id
+            )
+
+        try:
+            await send_new_salesforce_case_workflow_form(
+                client=self._app.client,
+                channel=channel_id,
+                user=user_id,
+                services=services,
+            )
+        except Exception:
+            logfire.exception("Failed to send ephemeral case form from custom workflow")
+            await fail(error="Failed to send case creation form.")
+            return
+
+        await complete(outputs={"status": "form_sent"})
 
     async def _handle_feedback_form_trigger(self, ack: AsyncAck, body: dict[str, Any]):
         await ack()

--- a/tiger_agent/slack/constants.py
+++ b/tiger_agent/slack/constants.py
@@ -7,6 +7,8 @@ AGENT_FEEDBACK_RECEIVED_SLACK_CHANNEL = os.environ.get(
     "AGENT_FEEDBACK_RECEIVED_SLACK_CHANNEL", None
 )
 
+CREATE_CASE_FUNCTION_ID = os.environ.get("CREATE_CASE_FUNCTION_ID", "create_case")
+
 CONFIRM_PROACTIVE_PROMPT = "confirm_proactive_prompt"
 REJECT_PROACTIVE_PROMPT = "reject_proactive_prompt"
 

--- a/tiger_agent/slack/slash_commands/handlers/salesforce/add_customer_channel.py
+++ b/tiger_agent/slack/slash_commands/handlers/salesforce/add_customer_channel.py
@@ -20,8 +20,7 @@ async def handle(ctx: CommandContext, args: list[str]) -> str:
         channel=channel_id,
         text=(
             f"Hi there! I'm {bot_name}. I'm here to help — you can get assistance by "
-            f"@mentioning {bot_mention} in this channel. If you need to open a support ticket, "
-            f"you can just ask {bot_mention} to help you create one."
+            f"@mentioning {bot_mention} in this channel."
         ),
     )
     return f"Assigned channel {channel_id} to Salesforce account id {salesforce_account_id}"

--- a/tiger_agent/slack/slash_commands/handlers/salesforce/add_customer_channel.py
+++ b/tiger_agent/slack/slash_commands/handlers/salesforce/add_customer_channel.py
@@ -2,7 +2,6 @@ from tiger_agent.db.utils import upsert_salesforce_account_id_for_channel
 from tiger_agent.slack.slash_commands.base import CommandContext
 from tiger_agent.slack.utils import (
     get_handle_link,
-    send_new_case_and_feedback_button,
 )
 
 
@@ -16,18 +15,13 @@ async def handle(ctx: CommandContext, args: list[str]) -> str:
     bot_name = ctx.bot_info.name if ctx.bot_info else "Support Bot"
     bot_user_id = ctx.bot_info.user_id if ctx.bot_info else None
     bot_mention = get_handle_link(bot_user_id) if bot_user_id else bot_name
+
     await ctx.hctx.app.client.chat_postMessage(
         channel=channel_id,
         text=(
             f"Hi there! I'm {bot_name}. I'm here to help — you can get assistance by "
-            f"@mentioning {bot_mention} in this channel, or open a support ticket by "
-            "clicking the button below. That button will be pinned to this channel for easy access."
+            f"@mentioning {bot_mention} in this channel. If you need to open a support ticket, "
+            f"you can just ask {bot_mention} to help you create one."
         ),
     )
-    ts = await send_new_case_and_feedback_button(
-        ctx.hctx.app.client, channel=channel_id
-    )
-    if ts:
-        await ctx.hctx.app.client.pins_add(channel=channel_id, timestamp=ts)
-
     return f"Assigned channel {channel_id} to Salesforce account id {salesforce_account_id}"

--- a/tiger_agent/slack/slash_commands/handlers/salesforce/add_customer_channel_specs.py
+++ b/tiger_agent/slack/slash_commands/handlers/salesforce/add_customer_channel_specs.py
@@ -11,7 +11,6 @@ def ctx(make_slack_command, make_bot_info):
     hctx = MagicMock()
     hctx.pool = MagicMock()
     hctx.app.client.chat_postMessage = AsyncMock()
-    hctx.app.client.pins_add = AsyncMock()
     return CommandContext(
         hctx=hctx, command=make_slack_command(), bot_info=make_bot_info()
     )
@@ -20,14 +19,10 @@ def ctx(make_slack_command, make_bot_info):
 @pytest.fixture(autouse=True)
 def patch_collaborators(monkeypatch):
     upsert = AsyncMock()
-    send_button = AsyncMock(return_value="1700000000.000100")
     monkeypatch.setattr(
         add_customer_channel, "upsert_salesforce_account_id_for_channel", upsert
     )
-    monkeypatch.setattr(
-        add_customer_channel, "send_new_case_and_feedback_button", send_button
-    )
-    return {"upsert": upsert, "send_button": send_button}
+    return {"upsert": upsert}
 
 
 class TestSalesforceAddCustomerChannelHandler:
@@ -50,18 +45,6 @@ class TestSalesforceAddCustomerChannelHandler:
         assert call_kwargs["channel"] == "C_CHAN"
         assert "I'm eon" in call_kwargs["text"]
         assert "<@U_BOT>" in call_kwargs["text"]
-
-    async def test_pins_button_message_when_ts_returned(self, ctx, patch_collaborators):
-        patch_collaborators["send_button"].return_value = "1700000000.000100"
-        await add_customer_channel.handle(ctx, ["C_CHAN", "0011x00000ABCDE"])
-        ctx.hctx.app.client.pins_add.assert_awaited_once_with(
-            channel="C_CHAN", timestamp="1700000000.000100"
-        )
-
-    async def test_does_not_pin_when_button_send_returns_none(self, ctx, patch_collaborators):
-        patch_collaborators["send_button"].return_value = None
-        await add_customer_channel.handle(ctx, ["C_CHAN", "0011x00000ABCDE"])
-        ctx.hctx.app.client.pins_add.assert_not_called()
 
     async def test_falls_back_to_support_bot_when_bot_info_missing(self, ctx):
         ctx.bot_info = None

--- a/tiger_agent/slack/utils.py
+++ b/tiger_agent/slack/utils.py
@@ -1207,6 +1207,10 @@ def get_channel_link(channel_id: str) -> str:
     return f"<#{channel_id}>"
 
 
+def channel_is_external(channel_info: ChannelInfo) -> bool:
+    return channel_info.is_ext_shared or channel_info.is_shared
+
+
 def user_is_external(bot_info: BotInfo, user_info: UserInfo) -> bool:
     # seemingly you can't trust Slacks' is_external fields
     # so this is going to compare the user's team with


### PR DESCRIPTION
## What
This adds a function handler for a new `create_case` Slack app initiated workflow function call. The manifest has been updated to include needed scopes and the workflow function interface definition (which defines the required inputs - user id and channel id).

This also adds a tool to the agent to be able to open a support ticket -- for instance @eon can you help me open a ticket? **Important** this fixed a moderate risk where all agent defined tools (like download slack file, download salesforce file) were avaible in customer channels. Moderate because all of the actual mcp tools marked `internal_only` cannot be used in customer channels. In a customer channel that is linked to a salesfoce account, the only tool returned is `create case`. In a customer channel that is not linked, there are no added client-side tools. 

Related: In order to allow external customers to be able to use pg-aiguide, I re-enabled that mcp in the eon mcp config. This is duplicating the doc tools as they are available via Tigerlabs, but is the most expedient way of allowing the doc tools to be given to LLM in a customer channel since Tigerlabs, itself, does not offer a good way to filter MCPs by the `internal_only` flat. See [PR](https://github.com/timescale/tiger-agents-deploy/pull/142)

Because this is a change to how customers create support tickets, this also updates the intro message that the agent sends to the customer channel after the channel is linked to a Salesforce account id. 


## Setup In Slack
New workflow created, adding the new `Create Case` workflow function step
<img width="715" height="453" alt="image" src="https://github.com/user-attachments/assets/3b415546-502c-4909-a9e4-0ac1c6111a81" />


with the following parameters (need to specify the value for each of these in the dropdown thing)
<img width="540" height="360" alt="image" src="https://github.com/user-attachments/assets/1ce86aab-ee2c-410a-b822-6d96ba69a774" />

This workflow is then added as a featured workflow in the desired customer channel
<img width="516" height="540" alt="image" src="https://github.com/user-attachments/assets/2981d00d-faa8-4339-9e36-aca583475f0d" />


And a new button appears like 
<img width="356" height="325" alt="image" src="https://github.com/user-attachments/assets/7e4dcf66-d95d-442a-ab8f-0e2134ef6a52" />

## Demo
<img width="1744" height="1388" alt="2026-09-04 20 16 36" src="https://github.com/user-attachments/assets/47425a89-fe7c-4d1c-99d7-037c2ef8012d" />

